### PR TITLE
temporarily remove the profile

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
-  profile = var.aws_profile
+  # profile = var.aws_profile
 
   default_tags {
     tags = local.common_tags


### PR DESCRIPTION
to temporarily remove the ci error : 

```
11:19:17  
Terraform has been successfully initialized!
11:19:21  
11:19:21  Error: failed to get shared config profile, terraform-developer
11:19:21  
11:19:21    with provider["registry.terraform.io/hashicorp/aws"],
11:19:21    on providers.tf line 1, in provider "aws":
11:19:21     1: provider "aws" {
11:19:21
```
