### PR TITLE
feat(network): Virtual Private Cloud (VPC) for the aws sponsored account

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,7 @@
 locals {
+  cluster_name   = "aws-sponso"
   aws_account_id = "326712726440"
-
+  region         = "us-east-1"
   common_tags = {
     "scope"      = "terraform-managed"
     "repository" = "jenkins-infra/terraform-aws-sponsorship"

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,96 @@
+resource "aws_security_group" "restricted_ssh" {
+  name        = "restricted-ssh"
+  description = "Allow inbound SSH only from trusted sources (admins or VPN)"
+  vpc_id      = module.vpc.default_vpc_id
+
+  tags = local.common_tags
+}
+
+resource "aws_security_group" "unrestricted_http" {
+  name        = "unrestricted-http"
+  description = "Allow HTTP(S) from everywhere (public services)"
+  vpc_id      = module.vpc.default_vpc_id
+
+  tags = local.common_tags
+}
+
+
+### WIP old rules, need to upgrade to new ones : https://github.com/jenkins-infra/helpdesk/issues/4320
+resource "aws_vpc_security_group_ingress_rule" "allow_ssh_from_admins" {
+  for_each = toset([
+    for ip in flatten(concat(
+      module.jenkins_infra_shared_data.outbound_ips["trusted.ci.jenkins.io"],              # permanent agent of update_center2
+      module.jenkins_infra_shared_data.outbound_ips["trusted.sponsorship.ci.jenkins.io"],  # ephemeral agents for crawler
+      module.jenkins_infra_shared_data.outbound_ips["privatek8s.jenkins.io"],              # VPN VM
+      module.jenkins_infra_shared_data.outbound_ips["infracijenkinsioagents1.jenkins.io"], # Terraform management and Docker-packaging build
+      module.jenkins_infra_shared_data.outbound_ips["private.vpn.jenkins.io"],             # connections routed through the VPN
+    )) : ip
+    if can(cidrnetmask("${ip}/32"))
+  ])
+
+  description       = "Allow admin (or platform) IPv4 for inbound SSH"
+  security_group_id = aws_security_group.restricted_ssh.id
+  cidr_ipv4         = "${each.value}/32"
+  from_port         = 22
+  ip_protocol       = "tcp"
+  to_port           = 22
+}
+
+## We WANT inbound 80 from everywhere
+#trivy:ignore:avd-aws-0107
+resource "aws_vpc_security_group_ingress_rule" "allow_http_from_internet" {
+  description       = "Allow HTTP from everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+## We WANT inbound 443 from everywhere
+#trivy:ignore:avd-aws-0107
+resource "aws_vpc_security_group_ingress_rule" "allow_https_from_internet" {
+  description       = "Allow HTTP from everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 443
+  ip_protocol       = "tcp"
+  to_port           = 443
+}
+
+## We WANT egress to internet (APT at least, but also outbound azcopy on some machines)
+#trivy:ignore:avd-aws-0104
+resource "aws_vpc_security_group_egress_rule" "allow_http_to_internet" {
+  description       = "Allow HTTP to everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 80
+  ip_protocol = "tcp"
+  to_port     = 80
+}
+
+## We WANT egress to internet (APT at least, but also outbound azcopy on some machines)
+#trivy:ignore:avd-aws-0104
+resource "aws_vpc_security_group_egress_rule" "allow_https_to_internet" {
+  description       = "Allow HTTPS to everywhere (public Internet)"
+  security_group_id = aws_security_group.unrestricted_http.id
+
+  cidr_ipv4   = "0.0.0.0/0"
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}
+
+## We WANT access from puppet master to puppet agents
+resource "aws_vpc_security_group_egress_rule" "allow_puppet_to_puppetmaster" {
+  description       = "Allow Puppet protocol to the Puppet master"
+  security_group_id = aws_security_group.unrestricted_http.id
+
+  # Ref. https://github.com/jenkins-infra/azure/blob/main/puppet.jenkins.io.tf
+  # TODO: automate retrieval of this IP with updatecli
+  cidr_ipv4   = "20.12.27.65/32"
+  from_port   = 8140
+  ip_protocol = "tcp"
+  to_port     = 8140
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,9 @@ variable "aws_profile" {
   default     = "terraform-developer"
   description = "AWS CLI profile to use with terraform"
 }
+
+variable "outbound_ip_count" {
+  type        = number
+  description = "Number of outbound IPs to use."
+  default     = 2
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,63 @@
+resource "aws_internet_gateway" "gw" {
+  vpc_id = module.vpc.default_vpc_id
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.13.0"
+
+  name = "${local.cluster_name}-vpc"
+  cidr = "10.0.0.0/16"
+
+
+  # dual stack https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/v5.13.0/examples/ipv6-dualstack/main.tf
+  enable_ipv6                                   = true
+  public_subnet_assign_ipv6_address_on_creation = true
+
+  manage_default_network_acl    = false
+  map_public_ip_on_launch       = true
+  manage_default_route_table    = false
+  manage_default_security_group = false
+
+  # only one zone, no need for multiple availability zones
+  azs = [local.region]
+
+  # only private subnets for security (to control allowed outbound connections)
+  private_subnets = [ # only one zone
+    # first VM ci.jenkins.io
+    "10.0.0.0/24", # 10.0.0.1 -> 10.0.0.254 (254 ips)
+    # second for VM agent jenkins
+    "10.1.0.0/20", # 10.1.0.1 -> 10.1.15.254 (4094 ips)
+    # next for eks agents
+    "10.2.0.0/20", # 10.2.0.1 -> 10.2.15.254 (4094 ips)
+  ]
+  public_subnets = [ # need at least one for the module (line 1085 : subnet_id = element(aws_subnet.public[*].id,var.single_nat_gateway ? 0 : count.index,))
+    #fake one
+    "10.254.0.0/24", # 10.254.0.1 -> 10.254.0.254 (254 ips)
+  ]
+
+  # One NAT gateway per subnet (default)
+  # ref. https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-subnet-default
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = false
+  ###### I cannot find a way to set a multiple IP for outgoing GW ... the count is not working
+  ###### https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#external-nat-gateway-ips
+  ######
+  ######  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway
+  ######
+  reuse_nat_ips       = true             # <= Skip creation of EIPs for the NAT Gateways
+  external_nat_ip_ids = aws_eip.nat.*.id # <= IPs specified here as input to the module
+  ###### I may have to create those aws_eip with name nat manually
+
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+}


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4320

create a VPC with 

- dual stack ipv4/ipv6
- 3 privates subnets (and 1 public as need at least one)
- no multi availability zones
- oubound request as ipv4 only but still missing the specific ip pool for the outbound gateway (using 1 per subnet for now).
- network restriction, same as AWS old account for now, will need improvement