### PR TITLE
hotfix(region): fix the region to us-east-1a

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,7 @@
 locals {
   cluster_name   = "aws-sponso"
   aws_account_id = "326712726440"
-  region         = "us-east-1"
+  region         = "us-east-1a"
   common_tags = {
     "scope"      = "terraform-managed"
     "repository" = "jenkins-infra/terraform-aws-sponsorship"


### PR DESCRIPTION
to solve 
```
creating EC2 Subnet: operation error EC2: CreateSubnet, https response error StatusCode: 400, RequestID: 3693c8ae-e940-4a5c-a1e2-375e49a7d8a0, api error InvalidParameterValue: Value (us-east-1) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: us-east-1a, us-east-1b, us-east-1c, us-east-1d, us-east-1e, us-east-1f.
```