### PR TITLE
hotfix(vpc) use the vpc_id instead of default vpc_id

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "restricted_ssh" {
   name        = "restricted-ssh"
   description = "Allow inbound SSH only from trusted sources (admins or VPN)"
-  vpc_id      = module.vpc.default_vpc_id
+  vpc_id      = module.vpc.vpc_id
 
   tags = local.common_tags
 }
@@ -9,7 +9,7 @@ resource "aws_security_group" "restricted_ssh" {
 resource "aws_security_group" "unrestricted_http" {
   name        = "unrestricted-http"
   description = "Allow HTTP(S) from everywhere (public services)"
-  vpc_id      = module.vpc.default_vpc_id
+  vpc_id      = module.vpc.vpc_id
 
   tags = local.common_tags
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,5 +1,5 @@
 resource "aws_internet_gateway" "gw" {
-  vpc_id = module.vpc.default_vpc_id
+  vpc_id = module.vpc.vpc_id
 }
 
 resource "aws_eip" "nat" {


### PR DESCRIPTION
following #16 use the vpc_id and not the default_vpc_id as per https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest?tab=outputs

ref https://github.com/jenkins-infra/helpdesk/issues/4320