### PR TITLE
chore(updatecli):Track aws terraform-provider version

### DIFF
--- a/updatecli/updatecli.d/terraform-providers/aws.yaml
+++ b/updatecli/updatecli.d/terraform-providers/aws.yaml
@@ -1,0 +1,46 @@
+name: "Bump Terraform `aws` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `aws` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: aws
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/aws
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `aws` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/aws

--- a/updatecli/updatecli.d/terraform-providers/aws.yaml
+++ b/updatecli/updatecli.d/terraform-providers/aws.yaml
@@ -34,6 +34,7 @@ targets:
         - linux_arm64
         - darwin_amd64
         - darwin_arm64
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4351

Added manifest to track and update aws terraform-provider version

Tested locally and successfully:

```
⚠ - changes detected:
        "hashicorp/aws" updated from "5.69.0" to "5.72.1" in file ".terraform.lock.hcl"


ACTIONS
========


=============================

SUMMARY:



⚠ Bump Terraform `aws` provider version:
        Source:
                ✔ [lastVersion] Get latest version of the `aws` provider
        Target:
                ⚠ [updateTerraformLockFile] Update Terraform lock file


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
 