### PR TITLE
chore(updatecli):Track and update azure outbound ips

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -3,12 +3,24 @@ locals {
   aws_account_id = "326712726440"
   region         = "us-east-2"
   our_az         = format("${local.region}%s", "b")
-  outbound_ips = { # source : https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
-    "trusted.ci.jenkins.io"              = ["104.209.128.236", "172.177.128.34", "172.210.175.108", "172.210.170.228"] # permanent agent of update_center2
-    "privatek8s.jenkins.io"              = ["20.65.63.127"]                                                            # VPN VM
-    "infracijenkinsioagents1.jenkins.io" = ["20.122.14.108", "20.186.70.154"]                                          # Terraform management and Docker-packaging build
-    "private.vpn.jenkins.io"             = ["172.176.126.194"]                                                         # connections routed through the VPN
+  ## Tracked bu updatecli from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+  ## Note: we use strings with space separator to manage type changes in updatecli's HCL parser
+  # permanent agent of update_center2
+  outbound_ips_trusted_ci_jenkins_io = "104.209.128.236 172.177.128.34 172.210.175.108 172.210.170.228"
+  # Infra.ci / Release CI controllers
+  outbound_ips_privatek8s_jenkins_io = "20.65.63.127"
+  # Terraform management and Docker-packaging build
+  outbound_ips_infracijenkinsioagents1_jenkins_io = "20.122.14.108 20.186.70.154"
+  # Connections routed through the VPN
+  outbound_ips_private_vpn_jenkins_io = "172.176.126.194"
+
+  outbound_ips = {
+    "trusted.ci.jenkins.io"              = split(" ", local.outbound_ips_trusted_ci_jenkins_io)
+    "privatek8s.jenkins.io"              = split(" ", local.outbound_ips_privatek8s_jenkins_io)
+    "infracijenkinsioagents1.jenkins.io" = split(" ", local.outbound_ips_infracijenkinsioagents1_jenkins_io)
+    "private.vpn.jenkins.io"             = split(" ", local.outbound_ips_private_vpn_jenkins_io)
   }
+
   common_tags = {
     "scope"      = "terraform-managed"
     "repository" = "jenkins-infra/terraform-aws-sponsorship"

--- a/updatecli/updatecli.d/outbound-ips.yaml
+++ b/updatecli/updatecli.d/outbound-ips.yaml
@@ -1,0 +1,97 @@
+name: Update outbound IPs from Azure Network report
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  trusted-ci-ips:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: trusted\.ci\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+  privatek8s-ips:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .privatek8s\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+  infra-ci-agents-ips:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .infracijenkinsioagents1\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+
+  private-vpn-ips:
+    kind: json
+    spec:
+      file: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+      key: .private\.vpn\.jenkins\.io.outbound_ips
+    transformers:
+      - trimprefix: "["
+      - trimsuffix: "]"
+      
+targets:
+  trusted-ci-update:
+    name: Update trusted.ci.jenkins.io IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_trusted_ci_jenkins_io
+    sourceid: trusted-ci-ips
+    scmid: default
+
+  privatek8s-update:
+    name: Update privatek8s.jenkins.io IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_privatek8s_jenkins_io
+    sourceid: privatek8s-ips
+    scmid: default
+
+  infra-ci-agents-update:
+    name: Update infracijenkinsioagents1.jenkins.io IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_infracijenkinsioagents1_jenkins_io
+    sourceid: infra-ci-agents-ips
+    scmid: default
+
+  private-vpn-update:
+    name: Update private_vpn.jenkins.io IPs
+    kind: hcl
+    spec:
+      file: locals.tf
+      path: locals.outbound_ips_private_vpn_jenkins_io
+    sourceid: private-vpn-ips
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update the terraform-aws-modules outbound IPs
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-modules-outbound-ips


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4352#issue-2586466201

Due to packers incapability of parsing nested hcl block keys, we use separate lists for each of the outbound-ips
(Ref: https://github.com/updatecli/updatecli/issues/1859)

This PR tracks and updates the azure outbound ips for `trusted.ci.jenkins.io` , `privatek8s.jenkins.io`, `infracijenkinsioagents1.jenkins.io`, and `private.vpn.jenkins.io`

Tested locally and successfully:

```
TARGETS
========

infra-ci-agents-update
----------------------

**Dry Run enabled**

✔ - no changes detected:
        path "locals.outbound_ips_infracijenkinsioagents1_jenkins_io" already set to "[\"20.122.14.108\", \"20.186.70.154\"]", from file "locals.tf", 

privatek8s-update
-----------------

**Dry Run enabled**

✔ - no changes detected:
        path "locals.outbound_ips_privatek8s_jenkins_io" already set to "[\"20.65.63.127\"]", from file "locals.tf", 

trusted-ci-update
-----------------

**Dry Run enabled**

✔ - no changes detected:
        path "locals.outbound_ips_trusted_ci_jenkins_io" already set to "[\"104.209.128.236\", \"172.177.128.34\", \"172.210.175.108\", \"172.210.170.228\"]", from file "locals.tf", 

private-vpn-update
------------------

**Dry Run enabled**

✔ - no changes detected:
        path "locals.outbound_ips_private_vpn_jenkins_io" already set to "[\"172.176.126.194\"]", from file "locals.tf", 


ACTIONS
========


=============================

SUMMARY:



✔ Update outbound IPs from Azure Network report:
        Source:
                ✔ [infra-ci-agents-ips] 
                ✔ [private-vpn-ips] 
                ✔ [privatek8s-ips] 
                ✔ [trusted-ci-ips] 
        Target:
                ✔ [infra-ci-agents-update] Update infracijenkinsioagents1.jenkins.io IPs
                ✔ [private-vpn-update] Update private_vpn.jenkins.io IPs
                ✔ [privatek8s-update] Update privatek8s.jenkins.io IPs
                ✔ [trusted-ci-update] Update trusted.ci.jenkins.io IPs


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1