### PR TITLE
fix(vpc) order subnets with array to avoid unexpected destroy/recreate when only adding subnets

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -50,29 +50,32 @@ locals {
   ## VPC Setup
   vpc_cidr = "10.0.0.0/16" # cannot be less then /16 (more ips)
   # Public subnets use the first partition of the vpc_cidr (index 0)
-  vpc_public_subnets = {
-    "controller" = {
-      az = format("${local.region}%s", "b"),
+  vpc_public_subnets = [
+    {
+      name = "controller",
+      az   = format("${local.region}%s", "b"),
       # First /23 of the first subset of the VPC (split in 2)
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[0], 6, 0)
     },
-  }
+  ]
   # Public subnets use the second partition of the vpc_cidr (index 1)
-  vpc_private_subnets = {
-    "vm-agents-1" = {
-      az = format("${local.region}%s", "b"),
+  vpc_private_subnets = [
+    {
+      name = "eks-1",
+      az   = format("${local.region}%s", "b"),
+      # Second /23 of the second subset of the VPC (split in 2)
+      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 1)
+    },
+    {
+      name = "vm-agents-1",
+      az   = format("${local.region}%s", "b"),
       # First /23 of the second subset of the VPC (split in 2)
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 0)
     },
-    "eks-1" = {
-      az = format("${local.region}%s", "b"),
-      # Second /23 of the second subset of the VPC (split in 2)
-      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 1)
-    }
-    "eks-2" = {
-      az = format("${local.region}%s", "c"),
+    { name = "eks-2",
+      az   = format("${local.region}%s", "c"),
       # Third /23 of the second subset of the VPC (split in 2)
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 2)
     }
-  }
+  ]
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -21,8 +21,8 @@ module "vpc" {
   azs = [for subnet_name, subnet_data in local.vpc_private_subnets : subnet_data.az]
 
   # only private subnets for security (to control allowed outbound connections)
-  private_subnets = [for subnet_name, subnet_data in local.vpc_private_subnets : subnet_data.cidr]
-  public_subnets  = [for subnet_name, subnet_data in local.vpc_public_subnets : subnet_data.cidr]
+  private_subnets = [for subnet in local.vpc_private_subnets : subnet.cidr]
+  public_subnets  = [for subnet in local.vpc_public_subnets : subnet.cidr]
 
   public_subnet_ipv6_prefixes  = range(length(local.vpc_public_subnets))
   private_subnet_ipv6_prefixes = range(10, length(local.vpc_private_subnets) + 10)


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319

Fixup of #36 to avoid #32 deployment failure

#36 did introduce a new data structure to declare subnets with automatic CIDR calculation.
Alas I used a `for` iteration to pass the data from the `locals` to the `vpc` module, which [used lexicographic order](https://developer.hashicorp.com/terraform/language/expressions/for#element-ordering).
So adding a new subnets in the data structure had the effect to expect a destroy-recreate (as it inserted `eks2` between the 2 existing subnets instead of after).

This PR switches the data structure to an array which order is kept by the iteration.
