### PR TITLE
fix(EKS) only use private subnets

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -1,131 +1,132 @@
-# # Define a KMS main key to encrypt the EKS cluster
-# resource "aws_kms_key" "cijenkinsio-agents-2" {
-#   description         = "EKS Secret Encryption Key for the cluster cijenkinsio-agents-2"
-#   enable_key_rotation = true
+# Define a KMS main key to encrypt the EKS cluster
+resource "aws_kms_key" "cijenkinsio-agents-2" {
+  description         = "EKS Secret Encryption Key for the cluster cijenkinsio-agents-2"
+  enable_key_rotation = true
 
-#   tags = merge(local.common_tags, {
-#     associated_service = "eks/cijenkinsio-agents-2"
-#   })
-# }
+  tags = merge(local.common_tags, {
+    associated_service = "eks/cijenkinsio-agents-2"
+  })
+}
 
-# # EKS Cluster definition
-# module "cijenkinsio-agents-2" {
-#   source  = "terraform-aws-modules/eks/aws"
-#   version = "20.29.0"
+# EKS Cluster definition
+module "cijenkinsio-agents-2" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.29.0"
 
-#   cluster_name = "cijenkinsio-agents-2"
-#   # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-#   cluster_version = "1.29"
-#   create_iam_role = true
+  cluster_name = "cijenkinsio-agents-2"
+  # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+  cluster_version = "1.29"
+  create_iam_role = true
 
-#   # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets
-#   subnet_ids = concat(
-#     slice(module.vpc.public_subnets, 1, 2),  # Public subnet required to allow egress to Internet, distinct from controller public subnet
-#     slice(module.vpc.private_subnets, 1, 3), # Private subnets: at least 2 in distincts AZ (EKS requirement), used by nodes
-#   )
-#   # Required to allow EKS service accounts to authenticate to AWS API through OIDC (and assume IAM roles)
-#   # useful for autoscaler, EKS addons and any AWS APi usage
-#   enable_irsa = true
+  # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets
+  # so 2 subnets at least (private ones)
+  subnet_ids = slice(module.vpc.private_subnets, 1, 3)
 
-#   # Allow the terraform CI IAM user to be co-owner of the cluster
-#   enable_cluster_creator_admin_permissions = true
+  # Required to allow EKS service accounts to authenticate to AWS API through OIDC (and assume IAM roles)
+  # useful for autoscaler, EKS addons and any AWS APi usage
+  enable_irsa = true
 
-#   # avoid using config map to specify admin accesses (decrease attack surface)
-#   authentication_mode = "API"
+  # Allow the terraform CI IAM user to be co-owner of the cluster
+  enable_cluster_creator_admin_permissions = true
 
-#   create_kms_key = false
-#   cluster_encryption_config = {
-#     provider_key_arn = aws_kms_key.cijenkinsio-agents-2.arn
-#     resources        = ["secrets"]
-#   }
+  # avoid using config map to specify admin accesses (decrease attack surface)
+  authentication_mode = "API"
 
-#   ## We only want to private access to the Control Plane except from infra.ci agents and VPN CIDRs (running outside AWS)
-#   cluster_endpoint_public_access       = true
-#   cluster_endpoint_public_access_cidrs = [for admin_ip in local.ssh_admin_ips : "${admin_ip}/32"]
-#   # Nodes and Pods require access to the Control Plane - https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-private
-#   # without needing to allow their IPs
-#   cluster_endpoint_private_access = true
+  create_kms_key = false
+  cluster_encryption_config = {
+    provider_key_arn = aws_kms_key.cijenkinsio-agents-2.arn
+    resources        = ["secrets"]
+  }
 
-#   create_cluster_primary_security_group_tags = false
+  ## We only want to private access to the Control Plane except from infra.ci agents and VPN CIDRs (running outside AWS)
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_public_access_cidrs = [for admin_ip in local.ssh_admin_ips : "${admin_ip}/32"]
+  # Nodes and Pods require access to the Control Plane - https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-private
+  # without needing to allow their IPs
+  cluster_endpoint_private_access = true
 
-#   # Do not use interpolated values from `local` in either keys and values of provided tags (or `cluster_tags)
-#   # To avoid having and implicit dependency to a resource not available when parsing the module (infamous errror `Error: Invalid for_each argument`)
-#   # Ref. same error as having a `depends_on` in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
-#   tags = merge(local.common_tags, {
-#     GithubRepo = "terraform-aws-sponsorship"
-#     GithubOrg  = "jenkins-infra"
+  create_cluster_primary_security_group_tags = false
 
-#     associated_service = "eks/cijenkinsio-agents-2"
-#   })
+  # Do not use interpolated values from `local` in either keys and values of provided tags (or `cluster_tags)
+  # To avoid having and implicit dependency to a resource not available when parsing the module (infamous errror `Error: Invalid for_each argument`)
+  # Ref. same error as having a `depends_on` in https://github.com/terraform-aws-modules/terraform-aws-eks/issues/2337
+  tags = merge(local.common_tags, {
+    GithubRepo = "terraform-aws-sponsorship"
+    GithubOrg  = "jenkins-infra"
 
-#   # VPC is defined in vpc.tf
-#   vpc_id = module.vpc.vpc_id
+    associated_service = "eks/cijenkinsio-agents-2"
+  })
 
-#   ## Manage EKS addons with module - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon
-#   # See new versions with `aws eks describe-addon-versions --kubernetes-version <k8s-version> --addon-name <addon>`
-#   cluster_addons = {
-#     # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-#     coredns = {
-#       addon_version = "v1.11.3-eksbuild.2"
-#     }
-#     # Kube-proxy on an Amazon EKS cluster has the same compatibility and skew policy as Kubernetes
-#     # See https://kubernetes.io/releases/version-skew-policy/#kube-proxy
-#     kube-proxy = {
-#       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-#       addon_version = "v1.29.10-eksbuild.3"
-#     }
-#     # https://github.com/aws/amazon-vpc-cni-k8s/releases
-#     vpc-cni = {
-#       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-#       addon_version = "v1.19.0-eksbuild.1"
-#     }
-#     eks-pod-identity-agent = {
-#       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-#       addon_version = "v1.3.4-eksbuild.1"
-#     }
-#     ## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md
-#     # aws-ebs-csi-driver = {
-#     #   # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-#     #   addon_version = "v1.37.0-eksbuild.1"
-#     #   # TODO specify service account
-#     #   # service_account_role_arn = module.cijenkinsio-agents-2_irsa_ebs.iam_role_arn
-#     # }
-#   }
+  # VPC is defined in vpc.tf
+  vpc_id = module.vpc.vpc_id
 
-#   eks_managed_node_groups = {
-#     tiny_ondemand_linux = {
-#       # This worker pool is expected to host the "technical" services such as pod autoscaler, etc.
-#       name = "tiny-ondemand-linux"
+  ## Manage EKS addons with module - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon
+  # See new versions with `aws eks describe-addon-versions --kubernetes-version <k8s-version> --addon-name <addon>`
+  cluster_addons = {
+    # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+    coredns = {
+      addon_version = "v1.11.3-eksbuild.2"
+    }
+    # Kube-proxy on an Amazon EKS cluster has the same compatibility and skew policy as Kubernetes
+    # See https://kubernetes.io/releases/version-skew-policy/#kube-proxy
+    kube-proxy = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = "v1.29.10-eksbuild.3"
+    }
+    # https://github.com/aws/amazon-vpc-cni-k8s/releases
+    vpc-cni = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = "v1.19.0-eksbuild.1"
+    }
+    eks-pod-identity-agent = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = "v1.3.4-eksbuild.1"
+    }
+    ## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md
+    # aws-ebs-csi-driver = {
+    #   # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+    #   addon_version = "v1.37.0-eksbuild.1"
+    #   # TODO specify service account
+    #   # service_account_role_arn = module.cijenkinsio-agents-2_irsa_ebs.iam_role_arn
+    # }
+  }
 
-#       instance_types = ["t4g.large"] # 2vcpu 8Gio
-#       capacity_type  = "ON_DEMAND"
-#       # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
-#       ami_type     = "AL2023_ARM_64_STANDARD"
-#       min_size     = 2
-#       max_size     = 3
-#       desired_size = 2
-#     },
-#   }
+  eks_managed_node_groups = {
+    tiny_ondemand_linux = {
+      # This worker pool is expected to host the "technical" services such as pod autoscaler, etc.
+      name = "tiny-ondemand-linux"
 
-#   # Allow egress from nodes (and pods...)
-#   node_security_group_additional_rules = {
-#     egress_jenkins_jnlp = {
-#       description      = "Allow egress to Jenkins TCP"
-#       protocol         = "TCP"
-#       from_port        = 50000
-#       to_port          = 50000
-#       type             = "egress"
-#       cidr_blocks      = ["0.0.0.0/0"]
-#       ipv6_cidr_blocks = ["::/0"]
-#     },
-#     egress_http = {
-#       description      = "Allow egress to plain HTTP"
-#       protocol         = "TCP"
-#       from_port        = 80
-#       to_port          = 80
-#       type             = "egress"
-#       cidr_blocks      = ["0.0.0.0/0"]
-#       ipv6_cidr_blocks = ["::/0"]
-#     },
-#   }
-# }
+      instance_types = ["t4g.large"] # 2vcpu 8Gio
+      capacity_type  = "ON_DEMAND"
+      # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
+      ami_type     = "AL2023_ARM_64_STANDARD"
+      min_size     = 1
+      max_size     = 3
+      desired_size = 1
+
+      subnet_ids = slice(module.vpc.private_subnets, 1, 2) # Only 1 subnet in 1 AZ
+    },
+  }
+
+  # Allow egress from nodes (and pods...)
+  node_security_group_additional_rules = {
+    egress_jenkins_jnlp = {
+      description      = "Allow egress to Jenkins TCP"
+      protocol         = "TCP"
+      from_port        = 50000
+      to_port          = 50000
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    },
+    egress_http = {
+      description      = "Allow egress to plain HTTP"
+      protocol         = "TCP"
+      from_port        = 80
+      to_port          = 80
+      type             = "egress"
+      cidr_blocks      = ["0.0.0.0/0"]
+      ipv6_cidr_blocks = ["::/0"]
+    },
+  }
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319

This PR has been tested successfully with a manual apply followed by cleanup (https://github.com/jenkins-infra/terraform-aws-sponsorship/commit/3acd958e4d80a8762d56025d574c752122706475).

It fixes the bootstrap errors we had (Node group creation failed due to node unable to join the cluster):

- Private endpoint must be enabled to allow nodes kubelet to contact the control plane. The alternative would be to allow the outbound IPs of the subnets used by Node groups to access the Control Plane but it requires much more configuration.
- Node groups must be tied to private subnet(s) to ensure they use the private endpoint
- The initial node group is using only 1 subnet in 1 AZ as a validation. We should have all Node groups to 2 AZs **unless** if they use an EBS volume (which is zonal).
- The EBS addon is disabled for now (as it requires an IRSA profile)
- The addon `eks-pod-identity-agent` is added as per the recommandation in the AWS Console UI