### PR TITLE
hotfix(vpc) private subnets: disable IPv6 and experiment around naming

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -9,8 +9,12 @@ module "vpc" {
   cidr = local.vpc_cidr
 
   # dual stack https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/v5.13.0/examples/ipv6-dualstack/main.tf
-  enable_ipv6                                   = true
-  public_subnet_assign_ipv6_address_on_creation = true
+  enable_ipv6                                                   = true
+  public_subnet_assign_ipv6_address_on_creation                 = true
+  private_subnet_assign_ipv6_address_on_creation                = false
+  private_subnet_ipv6_native                                    = false
+  private_subnet_enable_dns64                                   = false
+  private_subnet_enable_resource_name_dns_aaaa_record_on_launch = false
 
   manage_default_network_acl    = false
   map_public_ip_on_launch       = true
@@ -21,17 +25,24 @@ module "vpc" {
   azs = [for subnet_name, subnet_data in local.vpc_private_subnets : subnet_data.az]
 
   # only private subnets for security (to control allowed outbound connections)
-  private_subnets = [for subnet in local.vpc_private_subnets : subnet.cidr]
-  public_subnets  = [for subnet in local.vpc_public_subnets : subnet.cidr]
+  private_subnets      = [for subnet in local.vpc_private_subnets : subnet.cidr]
+  public_subnets       = [for subnet in local.vpc_public_subnets : subnet.cidr]
+  private_subnet_names = [for subnet in local.vpc_private_subnets : subnet.name]
+  private_subnet_tags  = local.common_tags
 
-  public_subnet_ipv6_prefixes  = range(length(local.vpc_public_subnets))
-  private_subnet_ipv6_prefixes = range(10, length(local.vpc_private_subnets) + 10)
+
+  # public_subnet_names = [for subnet in local.vpc_public_subnets : subnet.name]
+  # public_subnet_tags  = local.common_tags
+
+  public_subnet_ipv6_prefixes = range(length(local.vpc_public_subnets))
+
+  # private_subnet_ipv6_prefixes = range(10, length(local.vpc_private_subnets) + 10)
 
   # One NAT gateway per subnet (default)
   # ref. https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-subnet-default
-  enable_nat_gateway     = true
-  single_nat_gateway     = false
-  one_nat_gateway_per_az = false
+  enable_nat_gateway = true
+  single_nat_gateway = false
+  # one_nat_gateway_per_az = true
 
   enable_dns_hostnames = true
 }


### PR DESCRIPTION
This PR has been partially applied to solve the Internet routing problem we faced earlier (ref. https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2514275961 and https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2514272537).

It introduces(d) the following changes:

-Disable any IPv6 related feature on the private subnets: we don't need it simplifies the routing private -> NAT gateways -> public -> Egress only / Internet gateways
- Set up names and tags on the private subnets
  - TODO: same on public subnets. See commented lines


Note: I've added commented line. it's unusual but this PR is more of a "dump stuff to GH" than a real RFE