### PR TITLE
fix(network-security) extend dynamic ingress ports to allow NAT gateway in the controller public net

### DIFF
--- a/network-security.tf
+++ b/network-security.tf
@@ -65,16 +65,18 @@ resource "aws_network_acl" "ci_jenkins_io_controller" {
     rule_no    = 140
     action     = "allow"
     cidr_block = "0.0.0.0/0"
-    from_port  = 32768
-    to_port    = 65535
+    #  A NAT gateway uses ports 1024–65535
+    from_port = 1024
+    to_port   = 65535
   }
   ingress {
     protocol        = "tcp"
     rule_no         = 145
     action          = "allow"
     ipv6_cidr_block = "::/0"
-    from_port       = 32768
-    to_port         = 65535
+    #  A NAT gateway uses ports 1024–65535
+    from_port = 1024
+    to_port   = 65535
   }
 
   # Allow inbound TCP Jenkins Agent JNLP protocol from private subnets only
@@ -271,8 +273,9 @@ resource "aws_network_acl" "ci_jenkins_io_vm_agents" {
     rule_no    = 140
     action     = "allow"
     cidr_block = "0.0.0.0/0"
-    from_port  = 32768
-    to_port    = 65535
+    #  A NAT gateway uses ports 1024–65535
+    from_port = 1024
+    to_port   = 65535
   }
 }
 


### PR DESCRIPTION
Tested with success:

```
Started by user [dduportal](https://3.146.166.108/user/dduportal)
Loading library pipeline-library@master
Library pipeline-library@master is cached. Copying from cache.
[Pipeline] Start of Pipeline
[Pipeline] node
Still waiting to schedule task
‘[EC2 (aws-us-east-2) - ARM64 ubuntu 22.04 (i-0128fc1bafdb09492)](https://3.146.166.108/computer/EC2%20%28aws%2Dus%2Deast%2D2%29%20%2D%20ARM64%20ubuntu%2022%2E04%20%28i%2D0128fc1bafdb09492%29/)’ is offline
Running on [EC2 (aws-us-east-2) - ARM64 ubuntu 22.04 (i-0128fc1bafdb09492)](https://3.146.166.108/computer/EC2%20%28aws%2Dus%2Deast%2D2%29%20%2D%20ARM64%20ubuntu%2022%2E04%20%28i%2D0128fc1bafdb09492%29/) in /home/jenkins/agent/workspace/test
[Pipeline] {
[Pipeline] sh
+ mvn -v
Apache Maven 3.9.9 (8e8579a9e76f7d015ee5ec7bfcdc97d260186937)
Maven home: /usr/share/apache-maven-3.9.9
Java version: 21.0.5, vendor: Eclipse Adoptium, runtime: /opt/jdk-21
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.8.0-1019-aws", arch: "aarch64", family: "unix"
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
[Checks API] No suitable checks publisher found.
Finished: SUCCESS
```