### PR TITLE
feat(eks/ci-jenkins-io-2) allow infra-admin to administrate the new cluster

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -32,6 +32,24 @@ module "cijenkinsio-agents-2" {
   # avoid using config map to specify admin accesses (decrease attack surface)
   authentication_mode = "API"
 
+  access_entries = {
+    # One access entry with a policy associated
+    human_cluster_admins = {
+      principal_arn = "arn:aws:iam::326712726440:role/infra-admin"
+      type          = "STANDARD"
+
+      policy_associations = {
+        example = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type       = "cluster"
+            namespaces = null
+          }
+        }
+      }
+    }
+  }
+
   create_kms_key = false
   cluster_encryption_config = {
     provider_key_arn = aws_kms_key.cijenkinsio-agents-2.arn

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,9 @@ resource "local_file" "jenkins_infra_data_report" {
         ),
       },
     },
+    "cijenkinsio-agents-2" = {
+      "cluster_endpoint" = module.cijenkinsio-agents-2.cluster_endpoint
+    },
   })
   filename = "${path.module}/jenkins-infra-data-reports/aws-sponsorship.json"
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319

It also exports the cluster public endpoint to report to allow easy automation on VPN and puppet with `updatecli`