### PR TITLE
feat(eks/ci.jio-agents-2) add the admin SVC account used by kubernetes-management

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -47,6 +47,25 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.35.0"
+  hashes = [
+    "h1:r0Fs327r5OSmrFAJPcJC6wgpJqmJbZGNL7EAMeA1g+Y=",
+    "zh:059080ce30d4bf47ebce3bd09202c7f0e8fd7e734aeb2ace3dfbd1f1266c723c",
+    "zh:43f99c88ab344a8c108335a085483c8a786ff3194fe6acc279c1f4d8ff7a6603",
+    "zh:922aaa5766dacd0e4ef6eb401da538fe8d0ad1e79bfbb8e17dbfe86e6182d746",
+    "zh:a42b96a4570a1ba16556362a834a879d433395c8f1d8f24c0fc33c2cfd2065d9",
+    "zh:bf4271cc0f3cd81a1db34c150799cbe09ed6a131b185962a36a1e675767ef681",
+    "zh:c68cdb3c3b8aaf177af40e1cd1000d09e3a17d2610d8a125e4e6bf479d2efb71",
+    "zh:cf10a45e702af18fdec4fab30d8e6c447ab5cefa1ca9e2c94a3c9e802b7759c8",
+    "zh:d975dab312d2097700da1ea7aab1c1190e2acd99e5248f9be881093df2312bf4",
+    "zh:e297fdcb2ec49c7c77f1b2d793a7a6edaf6d9153036eb2aeaff9a3f4b9686bfa",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f607aa5b080a317c5ed353713cc33a4b3735e98bd4f4c15d33b494ae193db0b2",
+    "zh:f82baadbd4de5d3e4871672945be843a6540a339772b63db6dc3304860a4d97d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.2"
   hashes = [

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -148,3 +148,14 @@ module "cijenkinsio-agents-2" {
     },
   }
 }
+
+# Configure the jenkins-infra/kubernetes-management admin service account
+module "cijenkinsio-agents-2_admin_sa" {
+  providers = {
+    kubernetes = kubernetes.cijenkinsio-agents-2
+  }
+  source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
+  cluster_name               = module.cijenkinsio-agents-2.cluster_name
+  cluster_hostname           = module.cijenkinsio-agents-2.cluster_endpoint
+  cluster_ca_certificate_b64 = module.cijenkinsio-agents-2.cluster_certificate_authority_data
+}

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -159,3 +159,8 @@ module "cijenkinsio-agents-2_admin_sa" {
   cluster_hostname           = module.cijenkinsio-agents-2.cluster_endpoint
   cluster_ca_certificate_b64 = module.cijenkinsio-agents-2.cluster_certificate_authority_data
 }
+
+output "kubeconfig_cijenkinsio-agents-2" {
+  sensitive = true
+  value     = module.cijenkinsio-agents-2_admin_sa.kubeconfig
+}

--- a/providers.tf
+++ b/providers.tf
@@ -28,3 +28,9 @@ provider "time" {
 provider "tls" {
   # Required by the EKS module
 }
+
+provider "kubernetes" {
+  alias                  = "cijenkinsio-agents-2"
+  host                   = module.cijenkinsio-agents-2.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.cijenkinsio-agents-2.cluster_certificate_authority_data)
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319

This PR adds the admin service account we'll need to use to manage this cluster with kubernetes-management.

Note: this PR sets up the kubernetes provider, and it also proves that we can access the API from infra.ci agents