### PR TITLE
fix(eks/cijio-agents-2) add missing token for kubernetes provider

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -150,6 +150,17 @@ module "cijenkinsio-agents-2" {
 }
 
 # Configure the jenkins-infra/kubernetes-management admin service account
+data "aws_eks_cluster_auth" "cijenkinsio-agents-2" {
+  name = module.cijenkinsio-agents-2.cluster_name
+}
+
+provider "kubernetes" {
+  alias                  = "cijenkinsio-agents-2"
+  host                   = module.cijenkinsio-agents-2.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.cijenkinsio-agents-2.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cijenkinsio-agents-2.token
+}
+
 module "cijenkinsio-agents-2_admin_sa" {
   providers = {
     kubernetes = kubernetes.cijenkinsio-agents-2

--- a/providers.tf
+++ b/providers.tf
@@ -29,8 +29,7 @@ provider "tls" {
   # Required by the EKS module
 }
 
+# There are other kubernetes providers defined in other files with specific auth.
+# This one is a placeholder to ensure lock file has the proper setup
 provider "kubernetes" {
-  alias                  = "cijenkinsio-agents-2"
-  host                   = module.cijenkinsio-agents-2.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.cijenkinsio-agents-2.cluster_certificate_authority_data)
 }


### PR DESCRIPTION
Fixup of #62 which failed to deploy with errors like:

```
serviceaccounts is forbidden: User "system:anonymous" cannot create resource "serviceaccounts" in API group "" in the namespace "kube-system"
```

It uses the object https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth to generate a temporary token to authenticate in EKS using internal AWS Terraform provider setup (reusing the assumed role)