### PR TITLE
chore(outputs) export EC2 agents network informations

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -9,6 +9,13 @@ resource "local_file" "jenkins_infra_data_report" {
           [aws_eip.ci_jenkins_io.public_ip],         # Public IPv4 of the controller
         ),
       },
+      "ec2-agents" = {
+        "subnet_ids" = [module.vpc.private_subnets[0]],
+        "security_group_names" = [
+          aws_security_group.ephemeral_vm_agents.name,
+          aws_security_group.unrestricted_out_http.name,
+        ]
+      },
     },
     "cijenkinsio-agents-2" = {
       "cluster_endpoint" = module.cijenkinsio-agents-2.cluster_endpoint


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4316

Required to set up automatic update of puppet + JCasC setup 