### PR TITLE
Chore: enforce name conventions

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -1,5 +1,5 @@
 # Define a KMS main key to encrypt the EKS cluster
-resource "aws_kms_key" "cijenkinsio-agents-2" {
+resource "aws_kms_key" "cijenkinsio_agents_2" {
   description         = "EKS Secret Encryption Key for the cluster cijenkinsio-agents-2"
   enable_key_rotation = true
 
@@ -52,7 +52,7 @@ module "cijenkinsio-agents-2" {
 
   create_kms_key = false
   cluster_encryption_config = {
-    provider_key_arn = aws_kms_key.cijenkinsio-agents-2.arn
+    provider_key_arn = aws_kms_key.cijenkinsio_agents_2.arn
     resources        = ["secrets"]
   }
 

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -191,13 +191,13 @@ module "autoscaler_irsa_role" {
 }
 
 # Used by kubernetes/helm provider to authenticate to cluster with the AWS IAM identity (using a token)
-data "aws_eks_cluster_auth" "cijenkinsio-agents-2" {
+data "aws_eks_cluster_auth" "cijenkinsio_agents_2" {
   name = module.cijenkinsio_agents_2.cluster_name
 }
 
 ### Install Cluster Autoscaler
 resource "helm_release" "cluster-autoscaler" {
-  provider   = helm.cijenkinsio-agents-2
+  provider   = helm.cijenkinsio_agents_2
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
@@ -221,14 +221,14 @@ resource "helm_release" "cluster-autoscaler" {
 ### Define admin credential to be used in jenkins-infra/kubernetes-management
 module "cijenkinsio_agents_2_admin_sa" {
   providers = {
-    kubernetes = kubernetes.cijenkinsio-agents-2
+    kubernetes = kubernetes.cijenkinsio_agents_2
   }
   source                     = "./.shared-tools/terraform/modules/kubernetes-admin-sa"
   cluster_name               = module.cijenkinsio_agents_2.cluster_name
   cluster_hostname           = module.cijenkinsio_agents_2.cluster_endpoint
   cluster_ca_certificate_b64 = module.cijenkinsio_agents_2.cluster_certificate_authority_data
 }
-output "kubeconfig_cijenkinsio-agents-2" {
+output "kubeconfig_cijenkinsio_agents_2" {
   sensitive = true
   value     = module.cijenkinsio_agents_2_admin_sa.kubeconfig
 }

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -196,7 +196,7 @@ data "aws_eks_cluster_auth" "cijenkinsio_agents_2" {
 }
 
 ### Install Cluster Autoscaler
-resource "helm_release" "cluster-autoscaler" {
+resource "helm_release" "cluster_autoscaler" {
   provider   = helm.cijenkinsio_agents_2
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,5 @@
+moved {
+  from = aws_kms_key.cijenkinsio-agents-2
+  to = aws_kms_key.cijenkinsio_agents_2
+}
+

--- a/moved.tf
+++ b/moved.tf
@@ -10,3 +10,7 @@ moved {
   from = module.cijenkinsio-agents-2_admin_sa
   to   = module.cijenkinsio_agents_2_admin_sa
 }
+moved {
+  from = helm_release.cluster-autoscaler
+  to = helm_release.cluster_autoscaler
+}

--- a/moved.tf
+++ b/moved.tf
@@ -1,5 +1,12 @@
 moved {
   from = aws_kms_key.cijenkinsio-agents-2
-  to = aws_kms_key.cijenkinsio_agents_2
+  to   = aws_kms_key.cijenkinsio_agents_2
 }
-
+moved {
+  from = module.cijenkinsio-agents-2
+  to   = module.cijenkinsio_agents_2
+}
+moved {
+  from = module.cijenkinsio-agents-2_admin_sa
+  to   = module.cijenkinsio_agents_2_admin_sa
+}

--- a/moved.tf
+++ b/moved.tf
@@ -12,5 +12,5 @@ moved {
 }
 moved {
   from = helm_release.cluster-autoscaler
-  to = helm_release.cluster_autoscaler
+  to   = helm_release.cluster_autoscaler
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,7 @@ resource "local_file" "jenkins_infra_data_report" {
       },
     },
     "cijenkinsio-agents-2" = {
-      "cluster_endpoint" = module.cijenkinsio-agents-2.cluster_endpoint,
+      "cluster_endpoint" = module.cijenkinsio_agents_2.cluster_endpoint,
       "tolerations"      = local.cijenkinsio_agents_2["tolerations"],
     },
   })

--- a/providers.tf
+++ b/providers.tf
@@ -37,8 +37,8 @@ provider "tls" {
 provider "kubernetes" {
   alias = "cijenkinsio-agents-2"
 
-  host                   = module.cijenkinsio-agents-2.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.cijenkinsio-agents-2.cluster_certificate_authority_data)
+  host                   = module.cijenkinsio_agents_2.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.cijenkinsio-agents-2.token
 }
 
@@ -47,8 +47,8 @@ provider "helm" {
   alias = "cijenkinsio-agents-2"
 
   kubernetes {
-    host                   = module.cijenkinsio-agents-2.cluster_endpoint
+    host                   = module.cijenkinsio_agents_2.cluster_endpoint
     token                  = data.aws_eks_cluster_auth.cijenkinsio-agents-2.token
-    cluster_ca_certificate = base64decode(module.cijenkinsio-agents-2.cluster_certificate_authority_data)
+    cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -35,20 +35,20 @@ provider "tls" {
 
 # TODO track with updatecli
 provider "kubernetes" {
-  alias = "cijenkinsio-agents-2"
+  alias = "cijenkinsio_agents_2"
 
   host                   = module.cijenkinsio_agents_2.cluster_endpoint
   cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.cijenkinsio-agents-2.token
+  token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
 }
 
 # TODO track with updatecli
 provider "helm" {
-  alias = "cijenkinsio-agents-2"
+  alias = "cijenkinsio_agents_2"
 
   kubernetes {
     host                   = module.cijenkinsio_agents_2.cluster_endpoint
-    token                  = data.aws_eks_cluster_auth.cijenkinsio-agents-2.token
+    token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
     cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
   }
 }


### PR DESCRIPTION
following #67 renaming wrongly named resources

will need a subsequent PR to remove the `moved.tf` file.