### PR TITLE
feat(eks/ci.jenkins.io-agents-2) add EBS CSI storage classes for each zone

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,10 @@ locals {
       namespace      = "autoscaler",
       serviceaccount = "autoscaler",
     },
+    ebs-csi = {
+      namespace      = "kube-system",
+      serviceaccount = "ebs-csi-controller-sa",
+    },
     node_groups = {
       "applications" = {
         name = "applications"
@@ -30,6 +34,7 @@ locals {
         ],
       },
     },
+    subnets = ["eks-1", "eks-2"]
   }
 
   toleration_taint_effects = {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2569268640, this PR adds the EBS storage classes required to provide persistent storage for the Artifact Caching Proxy ("ACP") replicas.

Note: in order to provide storage classes, the EBS-CSI EKS Add-on is required. We add it as part of the PR with an associated IRSA profile, with the same method as what we used for the autoscaler.