### PR TITLE
feat(eks_ci_jio_agents2) adding an access entries for cijio to use within eks

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -51,7 +51,7 @@ module "cijenkinsio_agents_2" {
 
     # see https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html
     ci_jenkins_io = {
-      principal_arn =  aws_iam_instance_profile.arn
+      principal_arn =  aws_iam_instance_profile.ci_jenkins_io.arn
       type          = "STANDARD"
       kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups  # Create Kubernetes RoleBinding or ClusterRoleBinding objects on your cluster that specify the group name as a subject for kind: Group
     }

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -48,6 +48,13 @@ module "cijenkinsio_agents_2" {
         }
       }
     }
+
+    # see https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html
+    ci_jenkins_io = {
+      principal_arn =  aws_iam_instance_profile.arn
+      type          = "STANDARD"
+      kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups  # Create Kubernetes RoleBinding or ClusterRoleBinding objects on your cluster that specify the group name as a subject for kind: Group
+    }
   }
 
   create_kms_key = false

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -47,13 +47,11 @@ module "cijenkinsio_agents_2" {
           }
         }
       }
-    }
-
-    # see https://docs.aws.amazon.com/eks/latest/userguide/creating-access-entries.html
+    },
     ci_jenkins_io = {
       principal_arn =  aws_iam_instance_profile.ci_jenkins_io.arn
       type          = "STANDARD"
-      kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups  # Create Kubernetes RoleBinding or ClusterRoleBinding objects on your cluster that specify the group name as a subject for kind: Group
+      kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups
     }
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -21,6 +21,7 @@ locals {
       namespace      = "kube-system",
       serviceaccount = "ebs-csi-controller-sa",
     },
+    kubernetes_groups = ["cijio"],
     node_groups = {
       "applications" = {
         name = "applications"

--- a/locals.tf
+++ b/locals.tf
@@ -21,7 +21,7 @@ locals {
       namespace      = "kube-system",
       serviceaccount = "ebs-csi-controller-sa",
     },
-    kubernetes_groups = ["cijio"],
+    kubernetes_groups = ["ci-jenkins-io"],
     node_groups = {
       "applications" = {
         name = "applications"

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,7 @@ resource "local_file" "jenkins_infra_data_report" {
       },
       "cijenkinsio-agents-2" = {
         "cluster_endpoint" = module.cijenkinsio_agents_2.cluster_endpoint,
+        "kubernetes_groups" = local.cijenkinsio_agents_2.kubernetes_groups,
         "node_groups" = {
           "applications" = {
             "labels"      = module.cijenkinsio_agents_2.eks_managed_node_groups["applications"].node_group_labels


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2573143011
setting an Access Entry Configurations for the EKS Cluster to allow ci.jenkins.io to authentify within the eks cluster for agents 2.