### PR TITLE
fix(eks-cijio-agents2) principal arn to the role of ci.jio

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -49,7 +49,7 @@ module "cijenkinsio_agents_2" {
       }
     },
     ci_jenkins_io = {
-      principal_arn =  aws_iam_instance_profile.ci_jenkins_io.arn
+      principal_arn =  aws_iam_role.ci_jenkins_io.arn
       type          = "STANDARD"
       kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups
     }


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2573143011
following #76 

correcting the principal_arn to cijio role