### PR TITLE
chore(updatecli) tracks AWS Terraform module `irsa_role` version

### DIFF
--- a/updatecli/updatecli.d/irsa-role.yaml
+++ b/updatecli/updatecli.d/irsa-role.yaml
@@ -1,0 +1,59 @@
+name: Bump version of the Terraform "irsa_role" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestVersion:
+    kind: terraform/registry
+    name: Retrieve the latest version
+    spec:
+      type: module
+      namespace: terraform-aws-modules
+      name: iam
+      targetsystem: aws
+
+targets:
+  upgradeAutoscalerModuleVersion:
+    name: Update the Terraform "cijenkinsio_agents_2_autoscaler_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2_autoscaler_irsa_role.version
+
+  upgradeEbsCsiModuleVersion:
+    name: Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2_ebscsi_irsa_role.version
+
+actions:
+  upgradeAutoscalerModuleVersion:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_autoscaler_irsa_role" to {{ source "getLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-iam-role-module
+
+  upgradeEbsCsiModuleVersion:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_ebscsi_irsa_role" to {{ source "getLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-iam-role-module

--- a/updatecli/updatecli.d/irsa-role.yaml
+++ b/updatecli/updatecli.d/irsa-role.yaml
@@ -30,6 +30,7 @@ targets:
     spec:
       file: eks-cijenkinsio-agents-2.tf
       path: module.cijenkinsio_agents_2_autoscaler_irsa_role.version
+    scmid: default
 
   upgradeEbsCsiModuleVersion:
     name: Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
@@ -38,6 +39,7 @@ targets:
     spec:
       file: eks-cijenkinsio-agents-2.tf
       path: module.cijenkinsio_agents_2_ebscsi_irsa_role.version
+    scmid: default
 
 actions:
   upgradeAutoscalerModuleVersion:

--- a/updatecli/updatecli.d/irsa-role.yaml
+++ b/updatecli/updatecli.d/irsa-role.yaml
@@ -42,19 +42,10 @@ targets:
     scmid: default
 
 actions:
-  upgradeAutoscalerModuleVersion:
+  upgradeAwsIamModuleVersion:
     kind: github/pullrequest
     scmid: default
-    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_autoscaler_irsa_role" to {{ source "getLatestVersion" }}
-    spec:
-      labels:
-        - dependencies
-        - terraform-aws-iam-role-module
-
-  upgradeEbsCsiModuleVersion:
-    kind: github/pullrequest
-    scmid: default
-    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_ebscsi_irsa_role" to {{ source "getLatestVersion" }}
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_autoscaler_irsa_role" and "cijenkinsio_agents_2_ebscsi_irsa_role" to {{ source "getLatestVersion" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4478#issue-2772095173

this PR tracks and updates the AWS Terraform module `irsa_role` version

Tested locally with success:

```
TARGETS
========

upgradeEbsCsiModuleVersion
--------------------------

**Dry Run enabled**

✔ - no changes detected:
        path "module.cijenkinsio_agents_2_ebscsi_irsa_role.version" already set to "5.52.1", from file "eks-cijenkinsio-agents-2.tf", 

upgradeAutoscalerModuleVersion
------------------------------

**Dry Run enabled**

⚠ - changes detected:
        path "module.cijenkinsio_agents_2_autoscaler_irsa_role.version" updated from "5.48.0" to "5.52.1" in file "eks-cijenkinsio-agents-2.tf"


ACTIONS
========


=============================

SUMMARY:



⚠ Bump version of the Terraform "irsa_role" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf:
        Source:
                ✔ [getLatestVersion] Retrieve the latest version
        Target:
                ⚠ [upgradeAutoscalerModuleVersion] Update the Terraform "cijenkinsio_agents_2_autoscaler_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
                ✔ [upgradeEbsCsiModuleVersion] Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1