### PR TITLE
feat(ci.jenkins.io) allow WinRM and CIFs over TCP from controller to private agent subnets + disable Network ACLs

### DIFF
--- a/ci.jenkins.io-ec2-agents.tf
+++ b/ci.jenkins.io-ec2-agents.tf
@@ -1,5 +1,0 @@
-resource "aws_key_pair" "deployer" {
-  key_name   = "deployer-key"
-  public_key = trimspace(element(split("#", compact(split("\n", file("./ec2_agents_authorized_keys")))[0]), 0))
-  tags       = local.common_tags
-}

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -130,6 +130,13 @@ resource "aws_instance" "ci_jenkins_io" {
   )
 }
 
+## SSH Key used to access EC2 Agents (private key stored encrypted in SOPS)
+resource "aws_key_pair" "deployer" {
+  key_name   = "deployer-key"
+  public_key = trimspace(element(split("#", compact(split("\n", file("./ec2_agents_authorized_keys")))[0]), 0))
+  tags       = local.common_tags
+}
+
 ### DNS Zone delegated from Azure DNS (jenkins-infra/azure-net)
 # `updatecli` maintains sync between the 2 repositories using the infra reports (see outputs.tf)
 resource "aws_route53_zone" "aws_ci_jenkins_io" {

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -175,7 +175,7 @@ module "cijenkinsio_agents_2" {
 }
 
 module "cijenkinsio_agents_2_autoscaler_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.52.2"
 
   role_name                        = "${module.cijenkinsio_agents_2.cluster_name}-cluster-autoscaler"
@@ -194,7 +194,7 @@ module "cijenkinsio_agents_2_autoscaler_irsa_role" {
 }
 
 module "cijenkinsio_agents_2_ebscsi_irsa_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.52.2"
 
   role_name             = "${module.cijenkinsio_agents_2.cluster_name}-ebs-csi"

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,7 +17,7 @@ resource "local_file" "jenkins_infra_data_report" {
         ]
       },
       "cijenkinsio-agents-2" = {
-        "cluster_endpoint" = module.cijenkinsio_agents_2.cluster_endpoint,
+        "cluster_endpoint"  = module.cijenkinsio_agents_2.cluster_endpoint,
         "kubernetes_groups" = local.cijenkinsio_agents_2.kubernetes_groups,
         "node_groups" = {
           "applications" = {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4316

This PR sets the ground for prototying Windows EC2 agents using WinRM instead of SSH (see https://github.com/jenkins-infra/helpdesk/issues/4316#issuecomment-2571675608) which should be faster.

We need to open a set of ports to allow WinRM protocol (both HTTP and HTTPS channels), along with CIFS over TCP as per the [EC2 plugin](https://plugins.jenkins.io/ec2/) help:

<img width="1297" alt="Capture d’écran 2025-01-15 à 14 44 28" src="https://github.com/user-attachments/assets/c911b696-a5fc-478d-8a10-33f2a33390a8" />


Note: we are removing the Network ACLs here as a first step:

- If we can succeed in using WinRM, then we'll add them back (with the new rules)
- If we fail with WinRM or stick to SSH for Windows, then we'll rollback the Network ACL

