### PR TITLE
feat(ci.jio/securitygroups): allow https communication between ci.jio and eks cijenkinsio-agents-2

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -172,6 +172,18 @@ module "cijenkinsio_agents_2" {
       ipv6_cidr_blocks = ["::/0"]
     },
   }
+
+  # Allow ingress from ci.jenkins.io VM
+  cluster_security_group_additional_rules = {
+    ingress_https_cijio = {
+      description = "Allow ingress from ci.jenkins.io in https"
+      protocol    = "TCP"
+      from_port   = 443
+      to_port     = 443
+      type        = "ingress"
+      cidr_blocks = ["${aws_instance.ci_jenkins_io.private_ip}/32"]
+    },
+  }
 }
 
 module "cijenkinsio_agents_2_autoscaler_irsa_role" {

--- a/locals.tf
+++ b/locals.tf
@@ -13,6 +13,7 @@ locals {
   }
 
   cijenkinsio_agents_2 = {
+    api-ipsv4 = ["10.0.131.86/32", "10.0.133.102/32"]
     autoscaler = {
       namespace      = "autoscaler",
       serviceaccount = "autoscaler",

--- a/network-security.tf
+++ b/network-security.tf
@@ -552,3 +552,15 @@ resource "aws_vpc_security_group_ingress_rule" "allow_jnlp_in_private_subnets" {
   ip_protocol = "tcp"
   to_port     = 50000
 }
+
+resource "aws_vpc_security_group_egress_rule" "allow_https_out_to_eks_privates_ips" {
+  for_each = toset(local.cijenkinsio_agents_2.api-ipsv4)
+
+  description       = "Allow HTTPS to ip ${each.key} for eks api"
+  security_group_id = aws_security_group.ci_jenkins_io_controller.id
+
+  cidr_ipv4   = each.key
+  from_port   = 443
+  ip_protocol = "tcp"
+  to_port     = 443
+}


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4319

allowing network connexion between the aws ci.jenkins.io and the eks cijenkinsio-agents-2