### PR TITLE
feat(eks/ci.jenkins-agents-2) install karpenter with an IRSA

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -20,9 +20,10 @@ locals {
 
   cijenkinsio_agents_2 = {
     api-ipsv4 = ["10.0.131.86/32", "10.0.133.102/32"]
-    autoscaler = {
-      namespace      = "autoscaler",
-      serviceaccount = "autoscaler",
+    karpenter = {
+      node_role_name = "KarpenterNodeRole-cijenkinsio-agents-2",
+      namespace      = "karpenter",
+      serviceaccount = "karpenter",
     },
     awslb = {
       namespace      = "awslb"

--- a/updatecli/updatecli.d/irsa-role.yaml
+++ b/updatecli/updatecli.d/irsa-role.yaml
@@ -23,15 +23,6 @@ sources:
       targetsystem: aws
 
 targets:
-  upgradeAutoscalerModuleVersion:
-    name: Update the Terraform "cijenkinsio_agents_2_autoscaler_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
-    kind: hcl
-    sourceid: getLatestVersion
-    spec:
-      file: eks-cijenkinsio-agents-2.tf
-      path: module.cijenkinsio_agents_2_autoscaler_irsa_role.version
-    scmid: default
-
   upgradeEbsCsiModuleVersion:
     name: Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
     kind: hcl


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4319#issuecomment-2599000006

This PR installs Karpenter and removes cluster autoscaler in the EKS cluster `cijenkinsio-agents-2`.

It's the first Karpenter usages: I used https://karpenter.sh/v1.1/getting-started/getting-started-with-karpenter/#5-create-nodepool and https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/karpenter-mng/ as base documentation.

Tested manually with success with the following NodeGroup/Node manifest:

```yaml
apiVersion: karpenter.sh/v1
kind: NodePool
metadata:
  name: default
spec:
  template:
    spec:
      requirements:
        - key: kubernetes.io/arch
          operator: In
          values: ["amd64"]
        - key: kubernetes.io/os
          operator: In
          values: ["linux"]
        - key: karpenter.sh/capacity-type
          operator: In
          values: ["on-demand"]
        - key: karpenter.k8s.aws/instance-category
          operator: In
          values: ["c", "m", "r"]
        - key: karpenter.k8s.aws/instance-generation
          operator: Gt
          values: ["2"]
      nodeClassRef:
        group: karpenter.k8s.aws
        kind: EC2NodeClass
        name: default
      expireAfter: 720h # 30 * 24h = 720h
  limits:
    cpu: 1000
  disruption:
    consolidationPolicy: WhenEmptyOrUnderutilized
    consolidateAfter: 1m
---
apiVersion: karpenter.k8s.aws/v1
kind: EC2NodeClass
metadata:
  name: default
spec:
  amiFamily: AL2 # Amazon Linux 2
  role: "KarpenterNodeRole-cijenkinsio-agents-2" # replace with your cluster name
  subnetSelectorTerms:
    - id: subnet-031fd3566ba47fd32
    - id: subnet-02682a98ef4081887
  securityGroupSelectorTerms:
    - id: sg-023e03070920de908
  amiSelectorTerms:
    # aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.29/amazon-linux-2-arm64/recommended/image_id --query Parameter.Value --output text --profile=terraform-admin --region=us-east-2
    - id: "ami-0cfd84feed08d5c59" # arm64
    # aws ssm get-parameter --name /aws/service/eks/optimized-ami/1.29/amazon-linux-2/recommended/image_id --query Parameter.Value --output text --profile=terraform-admin --region=us-east-2
    - id: "ami-0738fb90ee1a8023b" # x86_64
```

and https://karpenter.sh/v1.1/getting-started/getting-started-with-karpenter/#6-scale-up-deployment

Note:

- NodeGroup / Node is a CRD. We'll want to use https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest to define them
- Windows Node group has not been tested (subsequent PR) yet