### PR TITLE
chore(updatecli) adds tracking for `ami_release_version` for EKS managed node groups

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -112,7 +112,6 @@ module "cijenkinsio_agents_2" {
       capacity_type  = "ON_DEMAND"
       # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
       ami_type = "AL2023_ARM_64_STANDARD"
-      # TODO: track with updatecli
       ami_release_version = local.cijenkinsio_agents_2_ami_release_version
       min_size            = 2
       max_size            = 3 # Usually 2 nodes, but accept 1 additional surging node

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -28,12 +28,19 @@ sources:
     spec:
       command: |
         set -e
-        release_version=$(aws ssm get-parameters-by-path \
+        echo "Fetching parameters..."
+        aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
-          --output json | jq -r '.[0] | fromjson | .release_version')
+          --output json > debug_output.json
+
+        echo "Debug output:"
+        cat debug_output.json
+        output=$(jq -r '.[0] | fromjson | .release_version' < debug_output.json)
+        echo "Release Version: $output"
+        echo $output
       environments:
           - name: PATH
           - name: AWS_ACCESS_KEY_ID

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -34,9 +34,7 @@ sources:
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
           --output json > text_output.json
-        cat text_output.json
         output=$(jq -r '.[0] | fromjson | .release_version' < text_output.json)
-        echo $output
       environments:
           - name: PATH
           - name: AWS_ACCESS_KEY_ID

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -28,17 +28,14 @@ sources:
     spec:
       command: |
         set -e
-        echo "Fetching parameters..."
         aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
-          --output json > debug_output.json
-        echo "Debug output:"
+          --output json > text_output.json
         cat debug_output.json
         output=$(jq -r '.[0] | fromjson | .release_version' < debug_output.json)
-        echo "Release Version: $output"
         echo $output
       environments:
           - name: PATH

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -28,13 +28,12 @@ sources:
     spec:
       command: |
         set -e
-        aws ssm get-parameters-by-path \
+        release_version=$(aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
-          --output json > text_output.json
-        output=$(jq -r '.[0] | fromjson | .release_version' < text_output.json)
+          --output json | jq -r '.[0] | fromjson | .release_version')
       environments:
           - name: PATH
           - name: AWS_ACCESS_KEY_ID

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -27,6 +27,7 @@ sources:
       - getClusterKubernetesVersion
     spec:
       command: |
+        which jq
         set -e
         output=$(aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -27,13 +27,15 @@ sources:
       - getClusterKubernetesVersion
     spec:
       command: |
-        # warning filter must match the ami_type
-        aws ssm get-parameters-by-path \
-          --path "/aws/service/eks/optimized-ami/{{ source "getClusterKubernetesVersion" }}/" \
+        set -e
+        output=$(aws ssm get-parameters-by-path \
+          --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
+          --profile terraform-admin \
           --region us-east-2 \
-          --output json | jq -r '.[0] | fromjson | .release_version'
+          --output json | jq -r '.[0] | fromjson | .release_version')
+        echo $output
       environments:
           - name: PATH
           - name: AWS_ACCESS_KEY_ID
@@ -50,8 +52,7 @@ targets:
     scmid: default
 
 actions:
-  amiReleasePR:
-    name: Create a pull request for updating the AMI release version
+  deafult:
     kind: github/pullrequest
     scmid: default
     title: Bump AMI release version for EKS managed node groups to {{ source "getLatestAmiReleaseVersion" }}

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -33,7 +33,6 @@ sources:
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
-          --profile terraform-admin \
           --region us-east-2 \
           --output json | jq -r '.[0] | fromjson | .release_version')
         echo $output

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -28,12 +28,17 @@ sources:
     spec:
       command: |
         set -e
-        output=$(aws ssm get-parameters-by-path \
+        echo "Fetching parameters..."
+        aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
-          --output json | jq -r '.[0] | fromjson | .release_version')
+          --output json > debug_output.json
+        echo "Debug output:"
+        cat debug_output.json
+        output=$(jq -r '.[0] | fromjson | .release_version' < debug_output.json)
+        echo "Release Version: $output"
         echo $output
       environments:
           - name: PATH

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -35,7 +35,7 @@ sources:
           --region us-east-2 \
           --output json > text_output.json
         cat debug_output.json
-        output=$(jq -r '.[0] | fromjson | .release_version' < debug_output.json)
+        output=$(jq -r '.[0] | fromjson | .release_version' < text_output.json)
         echo $output
       environments:
           - name: PATH

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -1,0 +1,61 @@
+name: Bump AMI release version for EKS managed node groups in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestAmiReleaseVersion:
+    kind: shell
+    name: Retrieve the ami_release_version version for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        # warning filter must match the ami_type
+        aws ssm get-parameters-by-path \
+          --path "/aws/service/eks/optimized-ami/{{ source "getClusterKubernetesVersion" }}/" \
+          --recursive \
+          --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
+          --region us-east-2 \
+          --output json | jq -r '.[0] | fromjson | .release_version'
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeAMIVersion:
+    name: Update the AMI release version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestAmiReleaseVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_ami_release_version
+    scmid: default
+
+actions:
+  amiReleasePR:
+    name: Create a pull request for updating the AMI release version
+    kind: github/pullrequest
+    scmid: default
+    title: Bump AMI release version for EKS managed node groups to {{ source "getLatestAmiReleaseVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-ami-release

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -51,7 +51,7 @@ targets:
     scmid: default
 
 actions:
-  deafult:
+  default:
     kind: github/pullrequest
     scmid: default
     title: Bump AMI release version for EKS managed node groups to {{ source "getLatestAmiReleaseVersion" }}

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -35,6 +35,10 @@ sources:
           --region us-east-2 \
           --output json | jq -r '.[0] | fromjson | .release_version')
         echo -n "$release_version"
+      environments:
+        - name: PATH
+        - name: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
 
 targets:
   upgradeAMIVersion:

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -28,23 +28,13 @@ sources:
     spec:
       command: |
         set -e
-        echo "Fetching parameters..."
-        aws ssm get-parameters-by-path \
+        release_version=$(aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \
           --recursive \
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
-          --output json > debug_output.json
-
-        echo "Debug output:"
-        cat debug_output.json
-        output=$(jq -r '.[0] | fromjson | .release_version' < debug_output.json)
-        echo "Release Version: $output"
-        echo $output
-      environments:
-          - name: PATH
-          - name: AWS_ACCESS_KEY_ID
-          - name: AWS_SECRET_ACCESS_KEY
+          --output json | jq -r '.[0] | fromjson | .release_version')
+        echo -n "$release_version"
 
 targets:
   upgradeAMIVersion:

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -34,7 +34,7 @@ sources:
           --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
           --region us-east-2 \
           --output json > text_output.json
-        cat debug_output.json
+        cat text_output.json
         output=$(jq -r '.[0] | fromjson | .release_version' < text_output.json)
         echo $output
       environments:

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -27,7 +27,6 @@ sources:
       - getClusterKubernetesVersion
     spec:
       command: |
-        which jq
         set -e
         output=$(aws ssm get-parameters-by-path \
           --path "/aws/service/eks/optimized-ami/1.29/" \


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4480

This PR track the `ami_release_version` used by eks_managed_node_groups.

We provide `ami_release_version` in locals to avoid parsing error by updatecli.

Tested locally with success.

```
TARGETS
========

upgradeAMIVersion
-----------------

**Dry Run enabled**

⚠ - changes detected:
        path "locals.cijenkinsio_agents_2_ami_release_version" updated from "1.29.10-20241213" to "1.29.12-20250116" in file "locals.tf"


ACTIONS
========


=============================

SUMMARY:



⚠ Bump AMI release version for EKS managed node groups in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf:
        Source:
                ✔ [getClusterKubernetesVersion] Retrieve the Kubernetes version used in the EKS cluster
                ✔ [getLatestAmiReleaseVersion] Retrieve the ami_release_version version for Kubernetes 1.29
        Target:
                ⚠ [upgradeAMIVersion] Update the AMI release version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1

