### PR TITLE
chore(ami_release_version) provides `ami_release_version` in `locals.tf` to avoid updatecli parsing error

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -113,7 +113,7 @@ module "cijenkinsio_agents_2" {
       # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
       ami_type = "AL2023_ARM_64_STANDARD"
       # TODO: track with updatecli
-      ami_release_version = "1.29.10-20241213"
+      ami_release_version = local.cijenkinsio_agents_2_ami_release_version
       min_size            = 2
       max_size            = 3 # Usually 2 nodes, but accept 1 additional surging node
       desired_size        = 2

--- a/locals.tf
+++ b/locals.tf
@@ -18,6 +18,8 @@ locals {
   cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.4-eksbuild.1"
   cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.38.1-eksbuild.1"
 
+  cijenkinsio_agents_2_ami_release_version = "1.29.10-20241213"
+
   cijenkinsio_agents_2 = {
     api-ipsv4 = ["10.0.131.86/32", "10.0.133.102/32"]
     karpenter = {


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4480

This PR provides `ami_release_version` version in` locals.tf` to avoid updatecli parsing error due to nested terraform paths