### PR TITLE
chore(updatecli) tracks EKS modules Terraform providers versions

### DIFF
--- a/updatecli/updatecli.d/terraform-providers/cloudinit.yaml
+++ b/updatecli/updatecli.d/terraform-providers/cloudinit.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `cloudinit` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `cloudinit` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: cloudinit
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/cloudinit
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `cloudinit` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/cloudinit

--- a/updatecli/updatecli.d/terraform-providers/helm.yaml
+++ b/updatecli/updatecli.d/terraform-providers/helm.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `helm` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `helm` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: helm
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/helm
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `helm` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/helm

--- a/updatecli/updatecli.d/terraform-providers/kubernetes.yaml
+++ b/updatecli/updatecli.d/terraform-providers/kubernetes.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `kubernetes` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `kubernetes` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: kubernetes
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/kubernetes
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `kubernetes` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/time

--- a/updatecli/updatecli.d/terraform-providers/null.yaml
+++ b/updatecli/updatecli.d/terraform-providers/null.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `null` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `null` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: "null"
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/null
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `null` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/null

--- a/updatecli/updatecli.d/terraform-providers/time.yaml
+++ b/updatecli/updatecli.d/terraform-providers/time.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `time` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `time` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: time
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/time
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `time` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/time

--- a/updatecli/updatecli.d/terraform-providers/tls.yaml
+++ b/updatecli/updatecli.d/terraform-providers/tls.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `tls` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `tls` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: tls
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/tls
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `tls` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/tls

--- a/versions.tf
+++ b/versions.tf
@@ -8,32 +8,26 @@ terraform {
     local = {
       source = "hashicorp/local"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     cloudinit = {
       source = "hashicorp/cloudinit"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     null = {
       source = "hashicorp/null"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     time = {
       source = "hashicorp/time"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     tls = {
       source = "hashicorp/tls"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
-    # TODO track with updatecli
     # Required by the EKS module
     helm = {
       source = "hashicorp/helm"


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4501

This PR tracks and updates the following terraform provider versions:

- cloudinit
- null
- time
- tls
- kubernetes
- helm