### PR TITLE
chore(updatecli) tracks AWS Terraform module `karpenter` version

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -223,7 +223,6 @@ module "cijenkinsio_agents_2_awslb_irsa_role" {
 ################################################################################
 module "cijenkinsio_agents_2_karpenter" {
   source = "terraform-aws-modules/eks/aws//modules/karpenter"
-  # TODO: track with updatecli
   version = "20.24"
 
   cluster_name          = module.cijenkinsio_agents_2.cluster_name

--- a/updatecli/updatecli.d/karpenter.yaml
+++ b/updatecli/updatecli.d/karpenter.yaml
@@ -1,0 +1,42 @@
+name: Bump version of the Terraform "karpenter" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestVersion:
+    kind: terraform/registry
+    name: Retrieve the latest version
+    spec:
+      type: module
+      namespace: terraform-aws-modules
+      name: eks
+      targetsystem: aws
+
+targets:
+  upgradeKarpenterModuleVersion:
+    name: Update the Terraform "cijenkinsio_agents_2_karpenter" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2_karpenter.version
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_karpenter" to {{ source "getLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-eks-karpenter-module


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4502

This PR tracks `karpenter` submodule from terraform registry.

https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/latest/submodules/karpenter

Tested locally with success.

```
TARGETS
========

upgradeKarpenterModuleVersion
-----------------------------

**Dry Run enabled**

⚠ - changes detected:
        path "module.cijenkinsio_agents_2_karpenter.version" updated from "20.24" to "20.33.0" in file "eks-cijenkinsio-agents-2.tf"


ACTIONS
========


=============================

SUMMARY:



⚠ Bump version of the Terraform "karpenter" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf:
        Source:
                ✔ [getLatestVersion] Retrieve the latest version
        Target:
                ⚠ [upgradeKarpenterModuleVersion] Update the Terraform "cijenkinsio_agents_2_karpenter" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1