### PR TITLE
chore(updatecli) tracks karpenter helm release version

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -276,6 +276,7 @@ resource "helm_release" "cijenkinsio_agents_2_awslb" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
+  # TODO: track with updatecli
   version          = "1.11.0"
   create_namespace = true
   namespace        = local.cijenkinsio_agents_2["awslb"]["namespace"]

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -276,7 +276,6 @@ resource "helm_release" "cijenkinsio_agents_2_awslb" {
   name       = "aws-load-balancer-controller"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-load-balancer-controller"
-  # TODO: track with updatecli
   version          = "1.11.0"
   create_namespace = true
   namespace        = local.cijenkinsio_agents_2["awslb"]["namespace"]

--- a/updatecli/updatecli.d/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/karpenter-helm-release.yaml
@@ -14,6 +14,7 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
+  # Logout step is required as described in Karpenter official documentation - https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter
   logoutPublicECR:
     name: Logout from public ECR registry via Helm CLI
     kind: shell

--- a/updatecli/updatecli.d/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/karpenter-helm-release.yaml
@@ -41,6 +41,7 @@ targets:
     spec:
       file: eks-cijenkinsio-agents-2.tf
       path: resource.helm_release.cijenkinsio_agents_2_karpenter.version
+    scmid: default
 
 actions:
   default:

--- a/updatecli/updatecli.d/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/karpenter-helm-release.yaml
@@ -14,18 +14,24 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
+  logoutPublicECR:
+    name: Logout from public ECR registry via Helm CLI
+    kind: shell
+    spec:
+      command: |
+        docker logout public.ecr.aws
+
   lastChartVersion:
     name: Karpenter AWS Provider Helm Chart Latest Version
-    kind: githubrelease
+    dependson:
+      - logoutPublicECR
+    kind: helmchart
     spec:
-      owner: aws
-      repository: karpenter-provider-aws
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionFilter:
-        kind: latest
-    transformers:
-      - trimprefix: "v"
+      url: oci://public.ecr.aws/karpenter
+      name: karpenter
+      versionfilter:
+        kind: semver
+        strict: true
 
 targets:
   updateChartVersion:
@@ -34,8 +40,7 @@ targets:
     sourceid: lastChartVersion
     spec:
       file: eks-cijenkinsio-agents-2.tf
-      path: resource.helm_release.karpenter.version
-    scmid: default
+      path: resource.helm_release.cijenkinsio_agents_2_karpenter.version
 
 actions:
   default:

--- a/updatecli/updatecli.d/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/karpenter-helm-release.yaml
@@ -1,0 +1,47 @@
+---
+name: Bump `karpenter` helm release version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastChartVersion:
+    name: Karpenter AWS Provider Helm Chart Latest Version
+    kind: githubrelease
+    spec:
+      owner: aws
+      repository: karpenter-provider-aws
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+    transformers:
+      - trimprefix: "v"
+
+targets:
+  updateChartVersion:
+    name: Update the helm release version for karpenter
+    kind: hcl
+    sourceid: lastChartVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: resource.helm_release.karpenter.version
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `karpenter` helm chart version to {{ source "lastChartVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - karpenter

--- a/updatecli/updatecli.d/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/karpenter-helm-release.yaml
@@ -35,6 +35,7 @@ targets:
     spec:
       file: eks-cijenkinsio-agents-2.tf
       path: resource.helm_release.karpenter.version
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/4504

This PR tracks terraform aws module `karpenter` helm release version by using github-release as source

Tested locally with success:

```
TARGETS
========

updateChartVersion
------------------

**Dry Run enabled**

✔ - no changes detected:
        path "resource.helm_release.karpenter.version" already set to "1.1.1", from file "eks-cijenkinsio-agents-2.tf", 
