### PR TITLE
feat(ci.jenkins.io) allow inbound JNLP from public NAT gateways IPs instead of private subnet CIDRs as we use public DNS

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -133,25 +133,15 @@ module "cijenkinsio_agents_2" {
     },
   }
 
-  # Allow egress from nodes (and pods...)
+  # Allow JNLP egress from pods to controller
   node_security_group_additional_rules = {
     egress_jenkins_jnlp = {
-      description      = "Allow egress to Jenkins TCP"
-      protocol         = "TCP"
-      from_port        = 50000
-      to_port          = 50000
-      type             = "egress"
-      cidr_blocks      = ["${aws_eip.ci_jenkins_io.public_ip}/32"]
-      ipv6_cidr_blocks = formatlist("%s/32", aws_instance.ci_jenkins_io.ipv6_addresses)
-    },
-    egress_http = {
-      description      = "Allow egress to plain HTTP"
-      protocol         = "TCP"
-      from_port        = 80
-      to_port          = 80
-      type             = "egress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
+      description = "Allow egress to Jenkins TCP"
+      protocol    = "TCP"
+      from_port   = 50000
+      to_port     = 50000
+      type        = "egress"
+      cidr_blocks = ["${aws_eip.ci_jenkins_io.public_ip}/32"]
     },
   }
 

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -141,8 +141,8 @@ module "cijenkinsio_agents_2" {
       from_port        = 50000
       to_port          = 50000
       type             = "egress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
+      cidr_blocks      = ["${aws_eip.ci_jenkins_io.public_ip}/32"]
+      ipv6_cidr_blocks = formatlist("%s/32", aws_instance.ci_jenkins_io.ipv6_addresses)
     },
     egress_http = {
       description      = "Allow egress to plain HTTP"

--- a/network-security.tf
+++ b/network-security.tf
@@ -553,12 +553,12 @@ resource "aws_vpc_security_group_egress_rule" "allow_cifs_out_private_subnets" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_jnlp_in_private_subnets" {
-  for_each = toset(module.vpc.private_subnets_cidr_blocks)
+  count = length(module.vpc.nat_public_ips)
 
-  description       = "Allow inbound JNLP Jenkins Agent protocol from private subnet ${each.key}"
+  description       = "Allow inbound JNLP Jenkins Agent protocol from agents outbound IP ${module.vpc.nat_public_ips[count.index]}"
   security_group_id = aws_security_group.ci_jenkins_io_controller.id
 
-  cidr_ipv4   = each.key
+  cidr_ipv4   = "${module.vpc.nat_public_ips[count.index]}/32"
   from_port   = 50000
   ip_protocol = "tcp"
   to_port     = 50000


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4317#issuecomment-2610543899

This PR introduces the following changes to the Security groups rules allowing the JNLP agent protocol for ci.jenkins.io:

- Allow the outbound public IP from agents (whether they are VMs or containers) instead of the private IP as the public IP of aws.ci.jenkins.io is ued
- Restrict the pod agents to:
  - Only outbound JNLP (no more plain HTTP)
  - Only the controller IPv4 public address
