### PR TITLE
feat(eks/ci.jenkins.io-agents-2) extend private IPv4 capacity

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -452,8 +452,9 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
         }
       ]
 
-      role                = module.cijenkinsio_agents_2_karpenter.node_iam_role_name
-      subnetSelectorTerms = [for subnet_id in slice(module.vpc.private_subnets, 1, 3) : { id = subnet_id }]
+      role = module.cijenkinsio_agents_2_karpenter.node_iam_role_name
+
+      subnetSelectorTerms = [for subnet_id in slice(module.vpc.private_subnets, 2, 4) : { id = subnet_id }]
       securityGroupSelectorTerms = [
         {
           id = module.cijenkinsio_agents_2.node_security_group_id

--- a/locals.tf
+++ b/locals.tf
@@ -94,7 +94,7 @@ locals {
         ],
       },
     ]
-    subnets = ["eks-1", "eks-2"]
+    subnets = ["eks-1", "eks-2", "eks-3"]
   }
 
   toleration_taint_effects = {
@@ -159,19 +159,26 @@ locals {
     {
       name = "vm-agents-1",
       az   = format("${local.region}%s", "b"),
-      # First /23 of the second subset of the VPC (split in 2)
+      # A /23 (the '6' integer argument) on the second subset of the VPC (split in 2)
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 0)
     },
     {
       name = "eks-1",
       az   = format("${local.region}%s", "a"),
-      # Second /23 of the second subset of the VPC (split in 2)
+      # A /23 (the '6' integer argument) on the second subset of the VPC (split in 2)
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 1)
     },
-    { name = "eks-2",
+    {
+      name = "eks-2",
       az   = format("${local.region}%s", "c"),
-      # Third /23 of the second subset of the VPC (split in 2)
-      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 2)
+      # A /21 (the '4' integer argument) on the second subset of the VPC (split in 2)
+      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 4, 2)
+    },
+    {
+      name = "eks-3",
+      az   = format("${local.region}%s", "a"),
+      # A /21 (the '4' integer argument) on the second subset of the VPC (split in 2)
+      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 4, 3)
     }
   ]
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4317#issuecomment-2612017565

This PR extends the EKS cluster `ci.jenkins.io-agents-2`) capacity in IPv4s:

- Increase the subnet 'eks-2' capacity from 512 to 2048 IPv4s (we filled it and almost filled 'eks-1' in a single BOM build so 1024 is a bit short)
- Add a new 'eks-3' subnet with 2048 IPv4s capacity in the AZ 'a' (same as `eks-1` subnet`)
- Set Karpenter Node pools to only use 'eks-2' and 'eks-3'
  - Still covers the same AZs ('c' and 'a')
  - Ensure that 'eks-1' stays for managed node groups, management applications, etc.