### PR TITLE
feat: add an ECR cache through registry

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -139,6 +139,26 @@ provider "registry.terraform.io/hashicorp/null" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.6.3"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.12.1"
   constraints = "0.12.1"

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -13,6 +13,11 @@ terraform(
     string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'production-terraform-aws-sponsorship-access-key'),
     string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-sponsorship-secret-key'),
     file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-aws-sponsorship-backend-config'),
+    usernamePassword(
+      credentialsId: 'infracijenkinsio-dockerhub-pull',
+      usernameVariable: 'TF_VAR_ecr_dockerhub_username',
+      passwordVariable: 'TF_VAR_ecr_dockerhub_token'
+    )
   ],
   publishReports: ['jenkins-infra-data-reports/aws-sponsorship.json'],
 )

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,54 @@
+module "secrets_manager" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  ## TODO: track with updatecli
+  version = "1.3.1"
+
+  name = "ecr-pullthroughcache/docker"
+  secret_string = jsonencode({
+    username    = var.ecr_dockerhub_username,
+    accessToken = var.ecr_dockerhub_token,
+  })
+  recovery_window_in_days = 0 # Set to 0 for testing purposes, this will immediately delete the secret. This action is irreversible. https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html
+}
+
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  ## TODO: track with updatecli
+  version = "2.3.1"
+
+  create_repository = false
+
+  registry_pull_through_cache_rules = {
+    ecr = {
+      ecr_repository_prefix = "ecr"
+      upstream_registry_url = "public.ecr.aws"
+    }
+    k8s = {
+      ecr_repository_prefix = "k8s"
+      upstream_registry_url = "registry.k8s.io"
+    }
+    quay = {
+      ecr_repository_prefix = "quay"
+      upstream_registry_url = "quay.io"
+    }
+    dockerhub = {
+      ecr_repository_prefix = "docker-hub"
+      upstream_registry_url = "registry-1.docker.io"
+      credential_arn        = module.secrets_manager.secret_arn
+    }
+  }
+
+  manage_registry_scanning_configuration = true
+  registry_scan_type                     = "ENHANCED"
+  registry_scan_rules = [
+    {
+      scan_frequency = "SCAN_ON_PUSH"
+      filter = [
+        {
+          filter      = "*"
+          filter_type = "WILDCARD"
+        },
+      ]
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,17 @@ variable "terratest" {
   description = "value"
   default     = false
 }
+
+## Secrets passed through the pipeline
+variable "ecr_dockerhub_username" {
+  description = "Docker Hub Username used by ECR Pull Through Cache"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+variable "ecr_dockerhub_token" {
+  description = "Docker Hub Token used by ECR Pull Through Cache"
+  type        = string
+  sensitive   = true
+  default     = ""
+}

--- a/versions.tf
+++ b/versions.tf
@@ -32,5 +32,10 @@ terraform {
     helm = {
       source = "hashicorp/helm"
     }
+    # Required by the secrets-manager module
+    ## TODO: track with updatecli
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }


### PR DESCRIPTION
Ref. nhttps://github.com/jenkins-infra/helpdesk/issues/4321#issuecomment-2643226880

Requires credential in the pipeline: https://github.com/jenkins-infra/kubernetes-management/pull/6200