### PR TITLE
fix(ci.jenkins.io) Increase instance size

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -85,7 +85,7 @@ resource "aws_key_pair" "ci_jenkins_io" {
 
 resource "aws_instance" "ci_jenkins_io" {
   ami           = "ami-0700ac71a4832f3b3" # Ubuntu 22.04 - arm64 - 2024-11-15 (no need to update it unless if recreating the VM)
-  instance_type = "m8g.xlarge"            # 4vcpu 16Go https://aws.amazon.com/fr/ec2/instance-types/
+  instance_type = "c7g.2xlarge"            # 8 vcpus Graviton 16Go https://aws.amazon.com/fr/ec2/instance-types/
 
   iam_instance_profile = aws_iam_instance_profile.ci_jenkins_io.name
 


### PR DESCRIPTION
The BOM builds have an increased amount of parallel stages. We used to have 200 with a quota of 150 max (e.g. around 50 pod agents creation waiting or retrying).

Now, with 1000 and a quota of 300, AND using arm64 CPU in AWS (instead of x64 in Azure), AND EBS instead of local instance NVMe, we see a lot of system interruption clobbering the whole CPU.

This PR changes the instance type:

- Using Compute family instead of general purpose (`c` instead of `m`)
- Move from 4 to 8 vCPUs to handle the IO and network interruptions
- Keep the same amount of memory as ci.jenkins.io does not use a lot of it


<img width="1583" alt="Capture d’écran 2025-02-14 à 12 50 27" src="https://github.com/user-attachments/assets/29998ada-1c8f-4d8b-807c-556ee9c835b4" />
<img width="1575" alt="Capture d’écran 2025-02-14 à 12 50 39" src="https://github.com/user-attachments/assets/f537b32e-d4f4-43b6-ba5e-a28313926740" />
<img width="1571" alt="Capture d’écran 2025-02-14 à 12 50 50" src="https://github.com/user-attachments/assets/8cdccf39-1c85-4611-82b7-7f4ad4f7a9a9" />
