### PR TITLE
fix(ci.jio-agents-2) add missing IAM permissions to EKS Node IAM role to support Windows nodes

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -85,7 +85,7 @@ resource "aws_key_pair" "ci_jenkins_io" {
 
 resource "aws_instance" "ci_jenkins_io" {
   ami           = "ami-0700ac71a4832f3b3" # Ubuntu 22.04 - arm64 - 2024-11-15 (no need to update it unless if recreating the VM)
-  instance_type = "c7g.2xlarge"            # 8 vcpus Graviton 16Go https://aws.amazon.com/fr/ec2/instance-types/
+  instance_type = "c7g.2xlarge"           # 8 vcpus Graviton 16Go https://aws.amazon.com/fr/ec2/instance-types/
 
   iam_instance_profile = aws_iam_instance_profile.ci_jenkins_io.name
 

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -243,11 +243,29 @@ module "cijenkinsio_agents_2_karpenter" {
   irsa_oidc_provider_arn          = module.cijenkinsio_agents_2.oidc_provider_arn
 
   # Used to attach additional IAM policies to the Karpenter node IAM role
-  # node_iam_role_additional_policies = {
-  #   AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-  # }
+  node_iam_role_additional_policies = {
+    EksWindows = aws_iam_policy.eks_windows.arn
+  }
 
   tags = local.common_tags
+}
+data "aws_iam_policy_document" "eks_windows" {
+  statement {
+    sid    = "EksWindows"
+    effect = "Allow"
+
+    actions = [
+      "eks:kube-proxy-windows",
+    ]
+
+    #tfsec:ignore:AWS099
+    resources = ["*"]
+  }
+}
+resource "aws_iam_policy" "eks_windows" {
+  name   = "eks-windows"
+  path   = "/"
+  policy = data.aws_iam_policy_document.eks_windows.json
 }
 # https://karpenter.sh/docs/troubleshooting/#missing-service-linked-role
 resource "aws_iam_service_linked_role" "ec2_spot" {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4318

Documented in https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support, point 5.