### PR TITLE
fix(ci.jio-agents-2) enable Windows IPAM support in VPC-CNI to support Windows Nodes

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -87,6 +87,11 @@ module "cijenkinsio_agents_2" {
     vpc-cni = {
       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
       addon_version = local.cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version
+      # Ensure vpc-cni changes are applied before any EC2 instances are created
+      before_compute = true
+      configuration_values = jsonencode({
+        enableWindowsIpam = "true"
+      })
     }
     ## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md
     aws-ebs-csi-driver = {


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4318

Documented in https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#enable-windows-support, point 3. and 4., but we use Terraform.
As such we followed the example in https://aws-ia.github.io/terraform-aws-eks-blueprints/snippets/vpc-cni-custom-networking/, with specific values from the chart in https://github.com/aws/eks-charts/blob/master/stable/aws-vpc-cni/README.md

