### PR TITLE
fix(ci.jio-agents-2) set up Karpenter to support 2 Windows Node pools (2019 and 2022)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,26 +45,27 @@ locals {
     }
     kubernetes_groups = ["ci-jenkins-io"],
     system_node_pool = {
-      name = "applications"
+      name = "applications",
       tolerations = [
         {
           "effect" : "NoSchedule",
           "key" : "${local.ci_jenkins_io["service_fqdn"]}/applications",
           "operator" : "Equal",
-          "value" : "true"
+          "value" : "true",
         },
       ],
     }
     karpenter_node_pools = [
       {
-        name         = "agents-linux-amd64"
-        os           = "linux"
-        architecture = "amd64"
-        spot         = true
+        name             = "agents-linux-amd64",
+        os               = "linux",
+        architecture     = "amd64",
+        consolidateAfter = "1m",
+        spot             = true,
         nodeLabels = {
           "jenkins" = "ci.jenkins.io",
           "role"    = "jenkins-agents",
-        }
+        },
         taints = [
           {
             "effect" : "NoSchedule",
@@ -75,50 +76,77 @@ locals {
         ],
       },
       {
-        name         = "agents-bom-linux-amd64"
-        os           = "linux"
-        architecture = "amd64"
-        spot         = true
+        name             = "agents-bom-linux-amd64",
+        os               = "linux",
+        architecture     = "amd64",
+        consolidateAfter = "1m",
+        spot             = true,
         nodeLabels = {
           "jenkins" = "ci.jenkins.io",
           "role"    = "jenkins-agents-bom",
-        }
+        },
         taints = [
           {
             "effect" : "NoSchedule",
             "key" : "${local.ci_jenkins_io["service_fqdn"]}/agents",
             "operator" : "Equal",
-            "value" : "true"
+            "value" : "true",
           },
           {
             "effect" : "NoSchedule",
             "key" : "${local.ci_jenkins_io["service_fqdn"]}/bom",
             "operator" : "Equal",
-            "value" : "true"
+            "value" : "true",
           },
         ],
       },
       {
-        name         = "agents-windows-amd64"
-        os           = "windows"
-        architecture = "amd64"
-        spot         = true
+        name             = "agents-windows-2022-amd64",
+        os               = "windows-2022",
+        architecture     = "amd64",
+        consolidateAfter = "30m",
+        spot             = true,
         nodeLabels = {
           "jenkins" = "ci.jenkins.io",
           "role"    = "jenkins-agents",
-        }
+        },
         taints = [
           {
             "effect" : "NoSchedule",
             "key" : "${local.ci_jenkins_io["service_fqdn"]}/agents",
             "operator" : "Equal",
-            "value" : "true"
+            "value" : "true",
           },
           {
             "effect" : "NoSchedule",
-            "key" : "${local.ci_jenkins_io["service_fqdn"]}/windows",
+            "key" : "${local.ci_jenkins_io["service_fqdn"]}/windows-2022",
             "operator" : "Equal",
-            "value" : "true"
+            "value" : "true",
+          },
+        ],
+      },
+      {
+        name             = "agents-windows-2019-amd64",
+        os               = "windows-2019",
+        architecture     = "amd64",
+        consolidateAfter = "30m",
+        spot             = true,
+        nodeLabels = {
+          "jenkins" = "ci.jenkins.io",
+          "role"    = "jenkins-agents",
+        },
+        taints = [
+          {
+            "effect" : "NoSchedule",
+            "key" : "${local.ci_jenkins_io["service_fqdn"]}/agents",
+            "operator" : "Equal",
+            "value" : "true",
+          },
+          {
+            "effect" : "NoSchedule",
+            "key" : "${local.ci_jenkins_io["service_fqdn"]}/windows-2019",
+            "operator" : "Equal",
+            "value" : "true",
           },
         ],
       },


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4318

This PR introduces the following changes in the EKS `ci.jenkins.io-agents-2` cluster's Karpenter setup:

- Support of both Windows 2019, 2022 (and eventually future new versions)
- Fix, on Windows, the device mapping of node to use the specified 300Gb EBS volume (instead of the default 20Gb)
- Allow customizing the default timeout on each node pool before letting Karpenter decide to cleanup or not
- Set up 2 Node pools for Windows 2019 (current usage) and Windows 2022 (upcoming usage) using distinct taints
  - Note: both are setting up the timeout (before considering node deletion) to 30 min as Windows node are billed per hour