### PR TITLE
Revert "cleanup: remove ECR resources" for EKS Node Pools

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,0 +1,54 @@
+module "secrets_manager" {
+  source = "terraform-aws-modules/secrets-manager/aws"
+  ## TODO: track with updatecli
+  version = "1.3.1"
+
+  name = "ecr-pullthroughcache/docker"
+  secret_string = jsonencode({
+    username    = var.ecr_dockerhub_username,
+    accessToken = var.ecr_dockerhub_token,
+  })
+  recovery_window_in_days = 0 # Set to 0 for testing purposes, this will immediately delete the secret. This action is irreversible. https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html
+}
+
+module "ecr" {
+  source = "terraform-aws-modules/ecr/aws"
+  ## TODO: track with updatecli
+  version = "2.3.1"
+
+  create_repository = false
+
+  registry_pull_through_cache_rules = {
+    ecr = {
+      ecr_repository_prefix = "ecr"
+      upstream_registry_url = "public.ecr.aws"
+    }
+    k8s = {
+      ecr_repository_prefix = "k8s"
+      upstream_registry_url = "registry.k8s.io"
+    }
+    quay = {
+      ecr_repository_prefix = "quay"
+      upstream_registry_url = "quay.io"
+    }
+    dockerhub = {
+      ecr_repository_prefix = "docker-hub"
+      upstream_registry_url = "registry-1.docker.io"
+      credential_arn        = module.secrets_manager.secret_arn
+    }
+  }
+
+  manage_registry_scanning_configuration = true
+  registry_scan_type                     = "ENHANCED"
+  registry_scan_rules = [
+    {
+      scan_frequency = "SCAN_ON_PUSH"
+      filter = [
+        {
+          filter      = "*"
+          filter_type = "WILDCARD"
+        },
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Reverts jenkins-infra/terraform-aws-sponsorship#123 as we need and ECR pull through for faster pod startups (since our image is heavy)
 
Related to https://github.com/jenkins-infra/helpdesk/issues/4318

Based from https://github.com/aws-ia/terraform-aws-eks-blueprints/tree/main/patterns/ecr-pull-through-cache
