### PR TITLE
feat(ci/jenkins.io-agents-2) bump Kubernetes to 1.30

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -7,7 +7,7 @@ module "cijenkinsio_agents_2" {
 
   cluster_name = "cijenkinsio-agents-2"
   # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-  cluster_version = "1.29"
+  cluster_version = "1.30"
   create_iam_role = true
 
   # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -482,7 +482,7 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
           # - WindowsXXXX only has the "latest" version available
           # - Amazon Linux 2023 is our default OS choice for Linux containers nodes
           # TODO: track AL2023 version with updatecli
-          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v20241213"
+          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v20250212"
         }
       ]
     }

--- a/locals.tf
+++ b/locals.tf
@@ -17,7 +17,7 @@ locals {
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version          = "v1.19.2-eksbuild.5"
   cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version = "v1.39.0-eksbuild.1"
 
-  cijenkinsio_agents_2_ami_release_version = "1.29.13-20250212"
+  cijenkinsio_agents_2_ami_release_version = "1.30.9-20250212"
 
   cijenkinsio_agents_2 = {
     api-ipsv4 = ["10.0.131.86/32", "10.0.133.102/32"]

--- a/locals.tf
+++ b/locals.tf
@@ -12,11 +12,10 @@ locals {
     controller_vm_fqdn = "aws.ci.jenkins.io"
   }
 
-  cijenkinsio_agents_2_cluster_addons_coredns_addon_version             = "v1.11.4-eksbuild.2"
-  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.29.13-eksbuild.3"
-  cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.19.2-eksbuild.5"
-  cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.4-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.39.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_coredns_addon_version         = "v1.11.4-eksbuild.2"
+  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version       = "v1.30.9-eksbuild.3"
+  cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version          = "v1.19.2-eksbuild.5"
+  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version = "v1.39.0-eksbuild.1"
 
   cijenkinsio_agents_2_ami_release_version = "1.29.13-20250212"
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4258