### PR TITLE
feat(ecr/eks) allow eks nodes to use ecr cache + move secret management to terraform-state

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -13,11 +13,6 @@ terraform(
     string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'production-terraform-aws-sponsorship-access-key'),
     string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-sponsorship-secret-key'),
     file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-aws-sponsorship-backend-config'),
-    usernamePassword(
-      credentialsId: 'infracijenkinsio-dockerhub-pull',
-      usernameVariable: 'TF_VAR_ecr_dockerhub_username',
-      passwordVariable: 'TF_VAR_ecr_dockerhub_token'
-    )
   ],
   publishReports: ['jenkins-infra-data-reports/aws-sponsorship.json'],
 )

--- a/ecr.tf
+++ b/ecr.tf
@@ -1,14 +1,5 @@
-module "secrets_manager" {
-  source = "terraform-aws-modules/secrets-manager/aws"
-  ## TODO: track with updatecli
-  version = "1.3.1"
-
-  name = "ecr-pullthroughcache/docker"
-  secret_string = jsonencode({
-    username    = var.ecr_dockerhub_username,
-    accessToken = var.ecr_dockerhub_token,
-  })
-  recovery_window_in_days = 0 # Set to 0 for testing purposes, this will immediately delete the secret. This action is irreversible. https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html
+data "aws_secretsmanager_secret" "dockerhub_readonly" {
+  name = "ecr-pullthroughcache/dockerhub"
 }
 
 module "ecr" {
@@ -34,7 +25,7 @@ module "ecr" {
     dockerhub = {
       ecr_repository_prefix = "docker-hub"
       upstream_registry_url = "registry-1.docker.io"
-      credential_arn        = module.secrets_manager.secret_arn
+      credential_arn        = data.aws_secretsmanager_secret.dockerhub_readonly.arn
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,17 +20,3 @@ variable "terratest" {
   description = "value"
   default     = false
 }
-
-## Secrets passed through the pipeline
-variable "ecr_dockerhub_username" {
-  description = "Docker Hub Username used by ECR Pull Through Cache"
-  type        = string
-  sensitive   = true
-  default     = ""
-}
-variable "ecr_dockerhub_token" {
-  description = "Docker Hub Token used by ECR Pull Through Cache"
-  type        = string
-  sensitive   = true
-  default     = ""
-}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4321