### PR TITLE
bump(terraform): upgrade to 1.11

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  required_version = ">= 1.10, <1.11"
+  required_version = ">= 1.11, <1.12"
   required_providers {
     aws = {
       source = "hashicorp/aws"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/packer-images/pull/1770 and https://github.com/jenkins-infra/packer-images/releases/tag/2.29.0 we need to accept terraform 1.11 