### PR TITLE
feat(ci.jenkins.io) increase instance size and EBS provisionned IOPS/threshold

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -85,7 +85,7 @@ resource "aws_key_pair" "ci_jenkins_io" {
 
 resource "aws_instance" "ci_jenkins_io" {
   ami           = "ami-0700ac71a4832f3b3" # Ubuntu 22.04 - arm64 - 2024-11-15 (no need to update it unless if recreating the VM)
-  instance_type = "c7g.2xlarge"           # 8 vcpus Graviton 16Go https://aws.amazon.com/fr/ec2/instance-types/
+  instance_type = "m7g.2xlarge"           # 8 vcpus Graviton 32Go https://aws.amazon.com/fr/ec2/instance-types/
 
   iam_instance_profile = aws_iam_instance_profile.ci_jenkins_io.name
 
@@ -110,6 +110,8 @@ resource "aws_instance" "ci_jenkins_io" {
     encrypted             = true
     volume_type           = "gp3"
     volume_size           = 500
+    throughput            = 200  # Mb/s. Default (and free) for gp3 is 125.
+    iops                  = 6000 # Default (and free) for gp3 is 3000.
 
     tags = local.common_tags
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4575#issuecomment-2701099787

This PR increases the instance sizing:

- CPU seems enough (already 8 vCPUs) as soon as it is not a `tX` family: the "user" process usage has a usage baseline between 40% and 60%. The "peaks" are due to system (IRQ/context switches) and/or IOwait which we want to avoid. So we keep 8 vCPUs.
- We need to give Jenkins more memory. Even if we start to fine tune GC, the amount of waiting threads when running a BOM builds need way more threads and memory space. Let's increase from 16 to 32.

- Cost increase:
  - Before: $215/month => c7g.2xlarge, $0.289/hour, (8/16 GiB), EBS Only, Up to 15 Gigabit
  - After: $243/month => m7g.2xlarge, $0.3264/hour, (8/32 GiB), EBS Only, Up to 15 Gigabit

It also adds provisioned IO on the EBS volume above the "free" limit (ref. https://aws.amazon.com/ebs/pricing/ and https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html). The instance metrics do not show any blocker during BOM build, but a bit of IOwait during controller restart when scanning the `JENKINS_HOME`.

But the EBS-side metrics shows we, sometimes, need a burst. As such, let's increase a bit: it should add around $18 per month.

Metrics in datadog and AWS:

<img width="1853" alt="Capture d’écran 2025-03-05 à 17 20 52" src="https://github.com/user-attachments/assets/29c53831-dba6-4f72-8c0b-c6f31def97a3" />

<img width="1630" alt="Capture d’écran 2025-03-05 à 17 30 09" src="https://github.com/user-attachments/assets/d81ac622-11e3-4a1b-b95c-1cb8bdaacd6d" />

<img width="1600" alt="Capture d’écran 2025-03-05 à 17 31 54" src="https://github.com/user-attachments/assets/b1722455-45f2-4252-a6f3-0b3ab89527c1" />
<img width="1608" alt="Capture d’écran 2025-03-05 à 17 30 21" src="https://github.com/user-attachments/assets/a924d4e0-f72e-4589-b9ad-10d322f52cea" />

