### PR TITLE
cleanup(eks-ci.jenkins.io-agents-1) remove Karpenter Windows Node Pool

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -3,7 +3,7 @@ data "aws_secretsmanager_secret" "dockerhub_readonly" {
 }
 
 module "ecr" {
-  source = "terraform-aws-modules/ecr/aws"
+  source  = "terraform-aws-modules/ecr/aws"
   version = "2.3.1"
 
   create_repository = false

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -90,6 +90,7 @@ module "cijenkinsio_agents_2" {
       # Ensure vpc-cni changes are applied before any EC2 instances are created
       before_compute = true
       configuration_values = jsonencode({
+        # Allow Windows NODE, but requires access entry for node IAM profile to be of kind 'EC2_WINDOWS' to get the proper IAM permissions (otherwise DNS does not resolve on Windows pods)
         enableWindowsIpam = "true"
       })
     }
@@ -240,6 +241,7 @@ module "cijenkinsio_agents_2_karpenter" {
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   version = "20.33.1"
 
+  # EC2_WINDOWS is a superset of EC2_LINUX to allow Windows nodes
   access_entry_type = "EC2_WINDOWS"
 
   cluster_name          = module.cijenkinsio_agents_2.cluster_name

--- a/locals.tf
+++ b/locals.tf
@@ -99,56 +99,6 @@ locals {
           },
         ],
       },
-      {
-        name             = "agents-windows-2022-amd64",
-        os               = "windows-2022",
-        architecture     = "amd64",
-        consolidateAfter = "30m",
-        spot             = true,
-        nodeLabels = {
-          "jenkins" = "ci.jenkins.io",
-          "role"    = "jenkins-agents",
-        },
-        taints = [
-          {
-            "effect" : "NoSchedule",
-            "key" : "${local.ci_jenkins_io["service_fqdn"]}/agents",
-            "operator" : "Equal",
-            "value" : "true",
-          },
-          {
-            "effect" : "NoSchedule",
-            "key" : "${local.ci_jenkins_io["service_fqdn"]}/windows-2022",
-            "operator" : "Equal",
-            "value" : "true",
-          },
-        ],
-      },
-      {
-        name             = "agents-windows-2019-amd64",
-        os               = "windows-2019",
-        architecture     = "amd64",
-        consolidateAfter = "30m",
-        spot             = true,
-        nodeLabels = {
-          "jenkins" = "ci.jenkins.io",
-          "role"    = "jenkins-agents",
-        },
-        taints = [
-          {
-            "effect" : "NoSchedule",
-            "key" : "${local.ci_jenkins_io["service_fqdn"]}/agents",
-            "operator" : "Equal",
-            "value" : "true",
-          },
-          {
-            "effect" : "NoSchedule",
-            "key" : "${local.ci_jenkins_io["service_fqdn"]}/windows-2019",
-            "operator" : "Equal",
-            "value" : "true",
-          },
-        ],
-      },
     ]
     subnets = ["eks-1", "eks-2", "eks-3"]
   }


### PR DESCRIPTION
but keep and document cluster Windows Node support.

Ref. https://github.com/jenkins-infra/helpdesk/issues/4554