### PR TITLE
feat(eks-ci.jenkins.io-agents-2) set up S3 bucket and its 2 persistent volumes to provide BOM caching

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -16,6 +16,9 @@ locals {
   cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version       = "v1.30.9-eksbuild.3"
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version          = "v1.19.3-eksbuild.1"
   cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version = "v1.40.0-eksbuild.1"
+  ## TODO track with updatecli
+  # aws eks describe-addon-versions --profile=jenkins-infra-developer --region=us-east-2 --kubernetes-version="1.30" --addon-name="aws-mountpoint-s3-csi-driver" --query 'addons[0].addonVersions[0].addonVersion' --output text
+  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version = "v1.12.0-eksbuild.1"
 
   cijenkinsio_agents_2_ami_release_version = "1.30.9-20250212"
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4525

This PR adds the following elements to the AWS infrastructure:

- The S3 CSI driver in the EKS cluster `ci.jenkins.io-agents-2` using the EKS add-on
  - No need to run the S3 CSI driver controller (managed thanks to the add-on)
  - The S3 CSI nodes are set up to tolerate all taints, e.g. all nodes may mount the S3 volumes.
- A (private) S3 bucket to store the cache files/folder
- The IAM identities and role required to allow the CSI driver to mount the S3 bucket as a virtual filesystem
- 2 statically provisioned PVs, already linked to their PVC (to avoid unwanted behavior such as using the default storage or unexpected PVCs trying to bind the PVs), pointing to the S3 bucket. One is ROX (to be used by build pod agents) and the other RWX (to be used to fill the cache)
  - Note: all UIDs are allowed to mount the volume. We may restrict to the UID `1000` eventually but I don't see how it would protect us from attacks through pod agents so better let it easy to manage.
- 2 statically provisioned PVCs associated to the PVs above
  - Note: both are defined in the BOM namespace, imported in Terraform as already created by https://github.com/jenkins-infra/kubernetes-management/blob/4f325413df38043acbbc754c0d9ba5406b6c5fef/clusters/cijioagents2.yaml#L49

Reference documentation of the AWS S3 Driver: https://github.com/awslabs/mountpoint-s3-csi-driver

----

Tested manually with the following pod definition:

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: s3-app
  namespace: jenkins-agents-bom
spec:
  containers:
    - name: app
      image: debian
      command: ["/bin/sh"]
      args: ["-c", "echo 'Hello from the container!' >> /data-rw/$(date -u).txt; tail -f /dev/null"]
      volumeMounts:
        - name: persistent-storage-ro
          mountPath: /data
        - name: persistent-storage-rw
          mountPath: /data-rw
  volumes:
    - name: persistent-storage-ro
      persistentVolumeClaim:
        claimName: "ci-jenkins-io-maven-cache-readonlymany"
    - name: persistent-storage-rw
      persistentVolumeClaim:
        claimName: "ci-jenkins-io-maven-cache-readwritemany"
  nodeSelector:
    jenkins: ci.jenkins.io
    kubernetes.io/arch: amd64
    role: jenkins-agents-bom
  tolerations:
  - effect: NoSchedule
    key: ci.jenkins.io/agents
    operator: Equal
    value: "true"
  - effect: NoSchedule
    key: ci.jenkins.io/bom
    operator: Equal
    value: "true"
```

----

Note: a new updatecli manifest is required to track the S3 CSI addon version introduced in this PR