### PR TITLE
feat(eks/ci.jenkins.io-agents-2) increase Karpenter Nodes root EBS throughput and ensure removal when node goes down

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -655,10 +655,12 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
           # Ref. https://karpenter.sh/docs/concepts/nodeclasses/#windows2019windows2022
           deviceName = startswith(each.value.os, "windows") ? "/dev/sda1" : "/dev/xvda"
           ebs = {
-            volumeSize = "300Gi"
-            volumeType = "gp3"
-            iops       = 3000
-            encrypted  = true
+            volumeSize          = "300Gi"
+            volumeType          = "gp3"
+            iops                = 3000 # Default (and free) is 3000
+            throughput          = 500  # Default (and free) is 125
+            deleteOnTermination = true
+            encrypted           = true
           }
         }
       ]


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4569#issuecomment-2715192712

Let's increase the throughput from 125 to 500 and check the result