### PR TITLE
feat(jenkinsfile_updatecli): Allow execution of `updatecli` in current node context

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,3 +1,4 @@
+@Library('pipeline-library@pull/916/head') _
 withCredentials([
     string(credentialsId: 'updatecli-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
     string(credentialsId: 'updatecli-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY')
@@ -7,6 +8,10 @@ withCredentials([
         properties([pipelineTriggers([cron('@daily')])])
         updatecli(action: 'apply')
     } else {
-        updatecli(action: 'diff')
+        updatecli([
+            action: 'diff',
+            version: '0.92.0',
+            runInCurrentAgent: true
+            ])
     }
 }


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/4539

This PR test the execution of `updatecli` in current node context ( Ref - https://github.com/jenkins-infra/pipeline-library/pull/916)