### PR TITLE
hotfix(network-security) specify explicitly subnets on default Network ACL to avoid constant changes

### DIFF
--- a/network-security.tf
+++ b/network-security.tf
@@ -10,6 +10,8 @@ import {
 resource "aws_default_network_acl" "default" {
   default_network_acl_id = module.vpc.default_network_acl_id
 
+  subnet_ids = concat(module.vpc.public_subnets, module.vpc.private_subnets)
+
   # Blocking abusive IPs - https://github.com/jenkins-infra/helpdesk/issues/4575
   ingress {
     protocol = -1


### PR DESCRIPTION

Fixup of #175 which did not show the change on the initial plan, because the way default VPC Network ACL does. Please read carefully terrafom's documentation about this resource if it is unclear to you.$

This PR ensure that the subnet IDs are specified on the default network ACL to avoid a constant change in all terraform plans.