### PR TITLE
hotfix(vpc) ensure S3 endpoint is a gateway routed from all subnets

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -46,7 +46,6 @@ module "vpc" {
 ################################################################################
 # VPC Endpoints Module
 ################################################################################
-
 module "vpc_endpoints" {
   source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
   #TODO track with updatecli
@@ -67,13 +66,16 @@ module "vpc_endpoints" {
   endpoints = {
     s3 = {
       service             = "s3"
+      service_type        = "Gateway"
+      route_table_ids     = concat(module.vpc.private_route_table_ids, module.vpc.public_route_table_ids)
       private_dns_enabled = true
-      dns_options = {
-        private_dns_only_for_inbound_resolver_endpoint = false
-      }
-      tags = { Name = "s3-vpc-endpoint" }
+      tags                = { Name = "s3-vpc-endpoint" }
     },
   }
 
   tags = local.common_tags
+}
+import {
+  id = "vpce-083c55de6549c4c43"
+  to = module.vpc_endpoints.aws_vpc_endpoint.this["s3"]
 }


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4600

This PR is a fixup of #184 in which we started with the examples from the AWS Terraform VPC which are using an Interface for S3 endpoint. But what we need is a Gateway associated to route tables.