### PR TITLE
hotfix(vpc) ensure there are only 1 subnet per AZ for ECR endpoints

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -74,14 +74,16 @@ module "vpc_endpoints" {
     ecr_api = {
       service             = "ecr.api"
       private_dns_enabled = true
-      subnet_ids          = concat(module.vpc.private_subnets, module.vpc.public_subnets)
-      policy              = data.aws_iam_policy_document.generic_endpoint_policy.json
+      # Requires only 1 subnet per AZ
+      subnet_ids = [for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.id... } : element(data, 0)]
+      policy     = data.aws_iam_policy_document.generic_endpoint_policy.json
     },
     ecr_dkr = {
       service             = "ecr.dkr"
       private_dns_enabled = true
-      subnet_ids          = concat(module.vpc.private_subnets, module.vpc.public_subnets)
-      policy              = data.aws_iam_policy_document.generic_endpoint_policy.json
+      # Requires only 1 subnet per AZ
+      subnet_ids = [for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.id... } : element(data, 0)]
+      policy     = data.aws_iam_policy_document.generic_endpoint_policy.json
     },
   }
 


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4600

Fixup of #184 to avoid the error

```
Error: creating EC2 VPC Endpoint (com.amazonaws.us-east-2.ecr.api): operation error EC2: CreateVpcEndpoint, https response error StatusCode: 400, RequestID: <redacted>, api error DuplicateSubnetsInSameZone: Found another VPC endpoint subnet in the availability zone of subnet-0c4211a4512f51839. VPC endpoint subnets should be in different availability zones supported by the VPC endpoint service.
```