### PR TITLE
feat(eks/ci.jenkins.io-agents-2) use the same AL2023 version for all Linux nodes

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -665,8 +665,7 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
           # Few notes about AMI aliases (ref. karpenter and AWS EKS docs.)
           # - WindowsXXXX only has the "latest" version available
           # - Amazon Linux 2023 is our default OS choice for Linux containers nodes
-          # TODO: track AL2023 version with updatecli
-          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v20250212"
+          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v${split("-", local.cijenkinsio_agents_2_ami_release_version)[1]}"
         }
       ]
     }


### PR DESCRIPTION
Closes https://github.com/jenkins-infra/terraform-aws-sponsorship/issues/144


This PR reuses the local used to specify the AMI AL2023 version of the "applications" node group.
This local is already tracked by updatecli \o/


This PR is expected to bump the AL2023 version for the Karpenter Linux nodes to `v20250317` (as per https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/192)