### PR TITLE
feat(eks/ci.jenkins.io-agents-2) introduces 3 new PVCs to support Maven caching

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -45,6 +45,14 @@ locals {
       subnet_ids = [for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.id... } : element(data, 0)],
       ips        = [for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.cidr_block... } : cidrhost(element(data, 0), "-9")],
     }
+    agent_namespaces = {
+      "jenkins-agents" = {
+        pods_quota = 150,
+      },
+      "jenkins-agents-bom" = {
+        pods_quota = 150,
+      },
+    },
     kubernetes_groups = ["ci-jenkins-io"],
     system_node_pool = {
       name = "applications",

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,16 +47,11 @@ resource "local_file" "jenkins_infra_data_report" {
           ips        = local.cijenkinsio_agents_2.docker_registry_mirror.ips,
         },
         "subnet_ids" = [module.vpc.private_subnets[1], module.vpc.private_subnets[2], module.vpc.private_subnets[3]],
-        maven_cache = {
-          readonly = {
-            namespace = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache["ReadOnlyMany"].metadata[0].namespace
-            pvc_name  = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache["ReadOnlyMany"].metadata[0].name
-          }
-          readwrite = {
-            namespace = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache["ReadWriteMany"].metadata[0].namespace
-            pvc_name  = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache["ReadWriteMany"].metadata[0].name
-          }
-        }
+        maven_cache_pvcs = merge(
+          { for agent_ns, agent_setup in local.cijenkinsio_agents_2.agent_namespaces :
+          agent_ns => kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_readonly[agent_ns].metadata[0].name },
+          { "${kubernetes_namespace.maven_cache.metadata[0].name}" = kubernetes_persistent_volume_claim.ci_jenkins_io_maven_cache_write.metadata[0].name },
+        ),
       },
       artifacts_manager = {
         s3_bucket_name = aws_s3_bucket.ci_jenkins_io_artifacts.bucket


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4525#issuecomment-2743849141

This PR introduces:

- 2 new PV/PVC (one per agent namespace) in readonly mode to allow agents to mount the PVC
  - Note: each PVC must have a 1:1 link with its PV, so 1 PV per PVC. It's due to how S3 CSI works
  - Note: the PVC name and namespaces have been added to the export to provide updatecli auto updates in Puppet. it includes the Pod quota for later usage
- 1 new PV/PVC in write namespace to allow cache populating
  - This new PVC needs a 1:1 lins with the PV
  - Also exported in the output
  - The PVC is in a new namespace

This PR is expected to break unit tests as it uses import directive.

Once merged:
- We might need hotfixes if we have unforeseen name limit (size, etc.)
- We'll have to cleanup the import/moved directives. Better to do it once we delete the 2 current existing PV/PVCs.