### PR TITLE
fix(vpc) ensure ECR endpoints only have 1 subnet per AZ

### DIFF
--- a/vpc.tf
+++ b/vpc.tf
@@ -74,15 +74,17 @@ module "vpc_endpoints" {
       service             = "ecr.dkr"
       service_type        = "Interface"
       private_dns_enabled = true
-      subnet_ids          = module.vpc.private_subnets
-      tags                = { Name = "com.amazonaws.${local.region}.ecr.dkr" }
+      # Only 1 subnet per AZ. ACP covers all of our AZs.
+      subnet_ids = local.cijenkinsio_agents_2.artifact_caching_proxy.subnet_ids
+      tags       = { Name = "com.amazonaws.${local.region}.ecr.dkr" }
     },
     ecr_dkr = {
       service             = "ecr.api"
       service_type        = "Interface"
       private_dns_enabled = true
-      subnet_ids          = module.vpc.private_subnets
-      tags                = { Name = "com.amazonaws.${local.region}.ecr.api" }
+      # Only 1 subnet per AZ. ACP covers all of our AZs.
+      subnet_ids = local.cijenkinsio_agents_2.artifact_caching_proxy.subnet_ids,
+      tags       = { Name = "com.amazonaws.${local.region}.ecr.api" }
     }
   }
 


### PR DESCRIPTION
Fixup of #231 

It should fix the following deployment error:

```
│ Error: creating EC2 VPC Endpoint (com.amazonaws.us-east-2.ecr.api): operation error EC2: CreateVpcEndpoint, https response error StatusCode: 400, RequestID: f2dd8c5f-3c8e-4a98-a07e-bf19d2d357aa, api error DuplicateSubnetsInSameZone: Found another VPC endpoint subnet in the availability zone of subnet-09672b042559be433. VPC endpoint subnets should be in different availability zones supported by the VPC endpoint service.
```