### PR TITLE
fix: ensure ci.jio controller VM is allowed to use the ECR pull-though cache

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -40,6 +40,17 @@ resource "aws_iam_role_policy" "ci_jenkins_io_ec2_agents" {
 
   policy = data.aws_iam_policy_document.jenkins_ec2_agents.json
 }
+# Permissions required by ECR (to allow using pull through after "aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <account ID>.dkr.ecr.<region>.amazonaws.com")
+resource "aws_iam_role_policy_attachment" "ci_jenkins_io_read_ecr" {
+  # AmazonEC2ContainerRegistryReadOnly
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.ci_jenkins_io.id
+}
+resource "aws_iam_role_policy_attachment" "ci_jenkins_io_ecrpullthroughcache" {
+  # ECRPullThroughCache
+  policy_arn = aws_iam_policy.ecrpullthroughcache.arn
+  role       = aws_iam_role.ci_jenkins_io.id
+}
 # Permissions required by Jenkins EC2 plugin in https://plugins.jenkins.io/ec2/#plugin-content-iam-setup
 data "aws_iam_policy_document" "jenkins_ec2_agents" {
   # Minimum set of permissions

--- a/ecr.tf
+++ b/ecr.tf
@@ -42,3 +42,24 @@ module "ecr" {
     }
   ]
 }
+
+resource "aws_iam_policy" "ecrpullthroughcache" {
+  name = "ECRPullThroughCache"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ecr:CreateRepository",
+          "ecr:BatchImportUpstreamImage",
+          "ecr:TagResource"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = local.common_tags
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -78,7 +78,7 @@ module "vpc_endpoints" {
       subnet_ids = local.cijenkinsio_agents_2.artifact_caching_proxy.subnet_ids
       tags       = { Name = "com.amazonaws.${local.region}.ecr.dkr" }
     },
-    ecr_dkr = {
+    ecr_api = {
       service             = "ecr.api"
       service_type        = "Interface"
       private_dns_enabled = true


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4688

This PR fixes setup of the ECR pull through cache so it can be used on ci.jenkins.io controller VM, as a "proof" that it works, even with the endpoints enabled.


- Added the ECR "pull through" IAM policy from #145
- (nit) bump shared tools to latest
- Attach policies to the ci.jio controller VM instance profile role:
  - AmazonEC2ContainerRegistryReadOnly
  - ECR "pull through" IAM policy created above
- Fix the ECR API and DKR endpoints (the first override the second due to same map key due a mistake I made in #230  🤦 )


----

Already applied manually and tested with success:

```
# From the Controller VM with Docker CE installed
aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin 326712726440.dkr.ecr.us-east-2.amazonaws.com
# Take some time but succeeds

docker pull 326712726440.dkr.ecr.us-east-2.amazonaws.com/docker-hub/jenkins/jenkins:lts-jdk21
```