### PR TITLE
chore: revert AWS provider to <6.0 to support latest EKS module

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,38 +2,32 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "6.0.0"
-  constraints = "6.0.0"
+  version     = "5.100.0"
+  constraints = "~> 5.0"
   hashes = [
-    "h1:DhxTTyLjzmC0wRCodYOWkIGwHAYb2Fcg3zFc/3sIpvk=",
-    "h1:F+INb3gR91dC+pr1ZB48IpOY6/a/G6tRcYA7evezqAI=",
-    "h1:W+H/RVJcygeLd5auWocMHJbHeBE19x010nD9bSsGe+8=",
-    "h1:dbRRZ1NzH1QV/+83xT/X3MLYaZobMXt8DNwbqnJojpo=",
-    "zh:16b1bb786719b7ebcddba3ab751b976ebf4006f7144afeebcb83f0c5f41f8eb9",
-    "zh:1fbc08b817b9eaf45a2b72ccba59f4ea19e7fcf017be29f5a9552b623eccc5bc",
-    "zh:304f58f3333dbe846cfbdfc2227e6ed77041ceea33b6183972f3f8ab51bd065f",
-    "zh:4cd447b5c24f14553bd6e1a0e4fea3c7d7b218cbb2316a3d93f1c5cb562c181b",
-    "zh:589472b56be8277558616075fc5480fcd812ba6dc70e8979375fc6d8750f83ef",
-    "zh:5d78484ba43c26f1ef6067c4150550b06fd39c5d4bfb790f92c4a6f7d9d0201b",
-    "zh:5f470ce664bffb22ace736643d2abe7ad45858022b652143bcd02d71d38d4e42",
-    "zh:7a9cbb947aaab8c885096bce5da22838ca482196cf7d04ffb8bdf7fd28003e47",
-    "zh:854df3e4c50675e727705a0eaa4f8d42ccd7df6a5efa2456f0205a9901ace019",
-    "zh:87162c0f47b1260f5969679dccb246cb528f27f01229d02fd30a8e2f9869ba2c",
-    "zh:9a145404d506b52078cd7060e6cbb83f8fc7953f3f63a5e7137d41f69d6317a3",
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a4eab2649f5afe06cc406ce2aaf9fd44dcf311123f48d344c255e93454c08921",
-    "zh:bea09141c6186a3e133413ae3a2e3d1aaf4f43466a6a468827287527edf21710",
-    "zh:d7ea2a35ff55ddfe639ab3b04331556b772a8698eca01f5d74151615d9f336db",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
   version = "2.3.7"
   hashes = [
-    "h1:Lt8lqrdNgZRlkOTwSXZTyuJkiVXnpwTsWAqHQPL6sIY=",
     "h1:M9TpQxKAE/hyOwytdX9MUNZw30HoD/OXqYIug5fkqH8=",
-    "h1:dgBaiMxxU61piW30emM6251LMFW66TbKR+p5ylPZvqc=",
-    "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
     "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
     "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
     "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
@@ -52,10 +46,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.3"
   hashes = [
-    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
-    "h1:836ukDqJMp3wnHO5XX1T4H14LcRhrrD8XxGh/WtqzCY=",
     "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
-    "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
     "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,33 +1,33 @@
-# resource "local_file" "jenkins_infra_data_report" {
-#   content = jsonencode({
-#     "${local.ci_jenkins_io["controller_vm_fqdn"]}" = {
-#       "name_servers" = aws_route53_zone.aws_ci_jenkins_io.name_servers,
-#       "service_ips" = {
-#         "ipv4" = aws_eip.ci_jenkins_io.public_ip,
-#         "ipv6" = aws_instance.ci_jenkins_io.ipv6_addresses[0],
-#       },
-#       "outbound_ips" = {
-#         "agents" = module.vpc.nat_public_ips,
-#         "controller" = concat(
-#           aws_instance.ci_jenkins_io.ipv6_addresses, # Public IPv6(s) (usually list of one element)
-#           [aws_eip.ci_jenkins_io.public_ip],         # Public IPv4 of the controller
-#         ),
-#       },
-#       "ec2-agents" = {
-#         "subnet_ids" = [module.vpc.private_subnets[0]],
-#         "security_group_names" = [
-#           aws_security_group.ephemeral_vm_agents.name,
-#           aws_security_group.unrestricted_out_http.name,
-#         ]
-#       },
-#       artifacts_manager = {
-#         s3_bucket_name = aws_s3_bucket.ci_jenkins_io_artifacts.bucket
-#       },
-#     },
+resource "local_file" "jenkins_infra_data_report" {
+  content = jsonencode({
+    # "${local.ci_jenkins_io["controller_vm_fqdn"]}" = {
+    #   "name_servers" = aws_route53_zone.aws_ci_jenkins_io.name_servers,
+    #   "service_ips" = {
+    #     "ipv4" = aws_eip.ci_jenkins_io.public_ip,
+    #     "ipv6" = aws_instance.ci_jenkins_io.ipv6_addresses[0],
+    #   },
+    #   "outbound_ips" = {
+    #     "agents" = module.vpc.nat_public_ips,
+    #     "controller" = concat(
+    #       aws_instance.ci_jenkins_io.ipv6_addresses, # Public IPv6(s) (usually list of one element)
+    #       [aws_eip.ci_jenkins_io.public_ip],         # Public IPv4 of the controller
+    #     ),
+    #   },
+    #   "ec2-agents" = {
+    #     "subnet_ids" = [module.vpc.private_subnets[0]],
+    #     "security_group_names" = [
+    #       aws_security_group.ephemeral_vm_agents.name,
+    #       aws_security_group.unrestricted_out_http.name,
+    #     ]
+    #   },
+    #   artifacts_manager = {
+    #     s3_bucket_name = aws_s3_bucket.ci_jenkins_io_artifacts.bucket
+    #   },
+    # },
 
-#   })
-#   filename = "${path.module}/jenkins-infra-data-reports/aws-sponsorship.json"
-# }
-# output "jenkins_infra_data_report" {
-#   value = local_file.jenkins_infra_data_report.content
-# }
+  })
+  filename = "${path.module}/jenkins-infra-data-reports/aws-sponsorship.json"
+}
+output "jenkins_infra_data_report" {
+  value = local_file.jenkins_infra_data_report.content
+}

--- a/updatecli/updatecli.d/terraform-modules/vpc.yaml.disabled
+++ b/updatecli/updatecli.d/terraform-modules/vpc.yaml.disabled
@@ -21,6 +21,11 @@ sources:
       namespace: terraform-aws-modules
       name: vpc
       targetsystem: aws
+      versionfilter:
+        kind: semver
+        # Until https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3386 is fixed
+        pattern: "~5"
+        strict: true
 
 targets:
   upgradeModuleVersion:

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
   required_version = ">= 1.12, <1.13"
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = "~> 6.0"
+      source = "hashicorp/aws"
+      # # Until https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3386 is fixed (note: also for VPC module)
+      version = "~> 5.0"
     }
     local = {
       source = "hashicorp/local"


### PR DESCRIPTION
- Ref. https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3386
- Reverts #240
- Add back a local report file to fix the main branch post build (failing after #243 )
- Updatecli will keep failing until #243 is reverted

Related to https://github.com/jenkins-infra/helpdesk/issues/4688#issuecomment-3011780540