### PR TITLE
feat: recreate EKS cluster `cijenkinsio-agents-2`

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -49,6 +49,28 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.36.0"
+  hashes = [
+    "h1:94wlXkBzfXwyLVuJVhMdzK+VGjFnMjdmFkYhQ1RUFhI=",
+    "h1:GLR3jKampPSDrt77O+cjTQrcE/EpQIiIA6sreenoon0=",
+    "h1:PjjQs2jN1zKWjDt84r1RK2ffbfi4Y2N3Aoa3avYWMZc=",
+    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
+    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
+    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
+    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
+    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
+    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
+    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
+    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
+    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
+    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
+    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.3"
   hashes = [

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -3,12 +3,9 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
-  constraints = "5.100.0"
+  constraints = ">= 4.0.0, >= 4.33.0, ~> 5.0, >= 5.79.0, >= 5.83.0, >= 5.93.0, >= 5.95.0, < 6.0.0"
   hashes = [
     "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
-    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
-    "h1:hd45qFU5cFuJMpFGdUniU9mVIr5LYVWP1uMeunBpYYs=",
-    "h1:wOhTPz6apLBuF7/FYZuCoXRK/MLgrNprZ3vXmq83g5k=",
     "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
     "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
     "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
@@ -28,12 +25,10 @@ provider "registry.terraform.io/hashicorp/aws" {
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
-  version = "2.3.7"
+  version     = "2.3.7"
+  constraints = ">= 2.0.0"
   hashes = [
-    "h1:Lt8lqrdNgZRlkOTwSXZTyuJkiVXnpwTsWAqHQPL6sIY=",
     "h1:M9TpQxKAE/hyOwytdX9MUNZw30HoD/OXqYIug5fkqH8=",
-    "h1:dgBaiMxxU61piW30emM6251LMFW66TbKR+p5ylPZvqc=",
-    "h1:iZ27qylcH/2bs685LJTKOKcQ+g7cF3VwN3kHMrzm4Ow=",
     "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
     "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
     "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
@@ -49,35 +44,49 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/kubernetes" {
-  version = "2.36.0"
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.0"
   hashes = [
-    "h1:94wlXkBzfXwyLVuJVhMdzK+VGjFnMjdmFkYhQ1RUFhI=",
-    "h1:GLR3jKampPSDrt77O+cjTQrcE/EpQIiIA6sreenoon0=",
-    "h1:PjjQs2jN1zKWjDt84r1RK2ffbfi4Y2N3Aoa3avYWMZc=",
-    "h1:vdY0sxo7ahwuz/y7flXTE04tSwn0Zhxyg6n62aTmAHI=",
-    "zh:07f38fcb7578984a3e2c8cf0397c880f6b3eb2a722a120a08a634a607ea495ca",
-    "zh:1adde61769c50dbb799d8bf8bfd5c8c504a37017dfd06c7820f82bcf44ca0d39",
-    "zh:39707f23ab58fd0e686967c0f973c0f5a39c14d6ccfc757f97c345fdd0cd4624",
-    "zh:4cc3dc2b5d06cc22d1c734f7162b0a8fdc61990ff9efb64e59412d65a7ccc92a",
-    "zh:8382dcb82ba7303715b5e67939e07dd1c8ecddbe01d12f39b82b2b7d7357e1d9",
-    "zh:88e8e4f90034186b8bfdea1b8d394621cbc46a064ff2418027e6dba6807d5227",
-    "zh:a6276a75ad170f76d88263fdb5f9558998bf3a3f7650d7bd3387b396410e59f3",
-    "zh:bc816c7e0606e5df98a0c7634b240bb0c8100c3107b8b17b554af702edc6a0c5",
-    "zh:cb2f31d58f37020e840af52755c18afd1f09a833c4903ac59270ab440fab57b7",
-    "zh:ee0d103b8d0089fb1918311683110b4492a9346f0471b136af46d3b019576b22",
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f688b9ec761721e401f6859c19c083e3be20a650426f4747cd359cdc079d212a",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.37.1"
+  hashes = [
+    "h1:+37jC6JlkPyPvDHudK3qaj7ZVJ0Zy9zc9+oq8h1WayA=",
+    "zh:0ed097413c7fc804479e325966886b405dc0b75ad2b4f54ce4df1d8e4802b397",
+    "zh:17dcf4a685a00d2d048671124e8a1a8e836b58ecd2ef628a1c666fe0ced2e598",
+    "zh:36891284e5bced57c438f12d0b27856b0d4b70b562bd200b01919a6a89545be9",
+    "zh:3e49d86b508e641ba122d1b0af24cdc4d8ffa2ec1b30022436fb1d7c6ba696ea",
+    "zh:40be623e116708bdcb0fac32989db43720f031c5fe9a4dc63395078185d24403",
+    "zh:44fc0ac3bc39e289b67f9dde7ee9fef29eb8192197e5e68fee69098573021722",
+    "zh:957aa451573bcde5d57f6f8338ea3139010c7f61fefe8f6a140a8c267f056511",
+    "zh:c55fd85b7e8acaac17e30670ac3574b88b3530820dd004bcd2a5daa8624a46e9",
+    "zh:c743f06843a1f5ecde2b8ef639f4d3db654a334ef248dee57261c719ea843f3a",
+    "zh:c93cc71c64b838d89522ac5fb60f68e0e1e7f2fc39db6b0ead7afd78795e79ed",
+    "zh:eda1163c2266905adc54bc78cc3e7b606a164fbc6b59be607db933b302015ccd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.5.3"
   hashes = [
-    "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
-    "h1:836ukDqJMp3wnHO5XX1T4H14LcRhrrD8XxGh/WtqzCY=",
     "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
-    "h1:Zy6RilIeIWBXksQWXjCLbqr9Om9R8cWX+axQlLebppM=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
     "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
@@ -90,6 +99,26 @@ provider "registry.terraform.io/hashicorp/local" {
     "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
     "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
     "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
   ]
 }
 
@@ -109,5 +138,45 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
     "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
     "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:zEv9tY1KR5vaLSyp2lkrucNJ+Vq3c+sTFK9GyQGLtFs=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
   ]
 }

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -1,0 +1,412 @@
+################################################################################
+# EKS Cluster ci.jenkins.io agents-2 definition
+################################################################################
+module "cijenkinsio_agents_2" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.29.0"
+
+  cluster_name = "cijenkinsio-agents-2"
+  # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+  cluster_version = "1.30"
+  create_iam_role = true
+
+  # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets
+  # so 2 subnets at least (private ones)
+  subnet_ids = slice(module.vpc.private_subnets, 1, 3)
+
+  # Required to allow EKS service accounts to authenticate to AWS API through OIDC (and assume IAM roles)
+  # useful for autoscaler, EKS addons and any AWS API usage
+  enable_irsa = true
+
+  # Allow the terraform CI IAM user to be co-owner of the cluster
+  enable_cluster_creator_admin_permissions = true
+
+  # Avoid using config map to specify admin accesses (decrease attack surface)
+  authentication_mode = "API"
+
+  access_entries = {
+    # One access entry with a policy associated
+    human_cluster_admins = {
+      principal_arn = "arn:aws:iam::326712726440:role/infra-admin"
+      type          = "STANDARD"
+
+      policy_associations = {
+        cluster_admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type       = "cluster"
+            namespaces = null
+          }
+        }
+      }
+    },
+    ci_jenkins_io = {
+      principal_arn     = aws_iam_role.ci_jenkins_io.arn
+      type              = "STANDARD"
+      kubernetes_groups = local.cijenkinsio_agents_2.kubernetes_groups
+    },
+  }
+
+  create_kms_key = false
+  cluster_encryption_config = {
+    provider_key_arn = aws_kms_key.cijenkinsio_agents_2.arn
+    resources        = ["secrets"]
+  }
+
+  ## We only want to private access to the Control Plane except from infra.ci agents and VPN CIDRs (running outside AWS)
+  cluster_endpoint_public_access       = true
+  cluster_endpoint_public_access_cidrs = [for admin_ip in local.ssh_admin_ips : "${admin_ip}/32"]
+  # Nodes and Pods require access to the Control Plane - https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html#cluster-endpoint-private
+  # without needing to allow their IPs
+  cluster_endpoint_private_access = true
+
+  tags = merge(local.common_tags, {
+    GithubRepo = "terraform-aws-sponsorship"
+    GithubOrg  = "jenkins-infra"
+
+    associated_service = "eks/cijenkinsio-agents-2"
+  })
+
+  vpc_id = module.vpc.vpc_id
+
+  cluster_addons = {
+    coredns = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_coredns_addon_version
+      configuration_values = jsonencode({
+        "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
+      })
+    }
+    # Kube-proxy on an Amazon EKS cluster has the same compatibility and skew policy as Kubernetes
+    # See https://kubernetes.io/releases/version-skew-policy/#kube-proxy
+    kube-proxy = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version
+    }
+    # https://github.com/aws/amazon-vpc-cni-k8s/releases
+    vpc-cni = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version
+      # Ensure vpc-cni changes are applied before any EC2 instances are created
+      before_compute = true
+      configuration_values = jsonencode({
+        # Allow Windows NODE, but requires access entry for node IAM profile to be of kind 'EC2_WINDOWS' to get the proper IAM permissions (otherwise DNS does not resolve on Windows pods)
+        enableWindowsIpam = "true"
+      })
+    }
+    ## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md
+    aws-ebs-csi-driver = {
+      # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version
+      configuration_values = jsonencode({
+        "controller" = {
+          "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
+        },
+        "node" = {
+          "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
+        },
+      })
+      service_account_role_arn = module.cijenkinsio_agents_2_ebscsi_irsa_role.iam_role_arn
+    },
+    ## https://github.com/awslabs/mountpoint-s3-csi-driver
+    aws-mountpoint-s3-csi-driver = {
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version
+      # resolve_conflicts_on_create = "OVERWRITE"
+      configuration_values = jsonencode({
+        "node" = {
+          "tolerateAllTaints" = true,
+        },
+      })
+      service_account_role_arn = aws_iam_role.s3_ci_jenkins_io_maven_cache.arn
+    }
+  }
+
+  eks_managed_node_groups = {
+    # This worker pool is expected to host the "technical" services such as karpenter, data cluster-agent, ACP, etc.
+    applications = {
+      name           = local.cijenkinsio_agents_2["system_node_pool"]["name"]
+      instance_types = ["t4g.xlarge"]
+      capacity_type  = "ON_DEMAND"
+      # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
+      ami_type            = "AL2023_ARM_64_STANDARD"
+      ami_release_version = local.cijenkinsio_agents_2_ami_release_version
+      min_size            = 2
+      max_size            = 3 # Usually 2 nodes, but accept 1 additional surging node
+      desired_size        = 2
+
+      subnet_ids = slice(module.vpc.private_subnets, 1, 2) # Only 1 subnet in 1 AZ (for EBS)
+
+      labels = {
+        jenkins = local.ci_jenkins_io["service_fqdn"]
+        role    = local.cijenkinsio_agents_2["system_node_pool"]["name"]
+      }
+      taints = { for toleration_key, toleration_value in local.cijenkinsio_agents_2["system_node_pool"]["tolerations"] :
+        toleration_key => {
+          key    = toleration_value["key"],
+          value  = toleration_value.value
+          effect = local.toleration_taint_effects[toleration_value.effect]
+        }
+      }
+
+      iam_role_additional_policies = {
+        AmazonEC2ContainerRegistryReadOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        additional                         = aws_iam_policy.ecrpullthroughcache.arn
+      }
+    },
+  }
+
+  # Allow JNLP egress from pods to controller
+  node_security_group_additional_rules = {
+    egress_jenkins_jnlp = {
+      description = "Allow egress to Jenkins TCP"
+      protocol    = "TCP"
+      from_port   = 50000
+      to_port     = 50000
+      type        = "egress"
+      cidr_blocks = ["${aws_eip.ci_jenkins_io.public_ip}/32"]
+    },
+    ingress_hub_mirror = {
+      description = "Allow ingress to Registry Pods"
+      protocol    = "TCP"
+      from_port   = 5000
+      to_port     = 5000
+      type        = "ingress"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress_hub_mirror_2 = {
+      description = "Allow ingress to Registry Pods with alternate port"
+      protocol    = "TCP"
+      from_port   = 8080
+      to_port     = 8080
+      type        = "ingress"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+  }
+
+  # Allow ingress from ci.jenkins.io VM
+  cluster_security_group_additional_rules = {
+    ingress_https_cijio = {
+      description = "Allow ingress from ci.jenkins.io in https"
+      protocol    = "TCP"
+      from_port   = 443
+      to_port     = 443
+      type        = "ingress"
+      cidr_blocks = ["${aws_instance.ci_jenkins_io.private_ip}/32"]
+    },
+  }
+}
+
+################################################################################
+# S3 Persistent Volume Resources
+################################################################################
+resource "aws_s3_bucket" "ci_jenkins_io_maven_cache" {
+  bucket        = "ci-jenkins-io-maven-cache"
+  force_destroy = true
+
+  tags = local.common_tags
+}
+resource "aws_s3_bucket_public_access_block" "ci_jenkins_io_maven_cache" {
+  bucket                  = aws_s3_bucket.ci_jenkins_io_maven_cache.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+resource "aws_iam_policy" "s3_ci_jenkins_io_maven_cache" {
+  name        = "s3-ci-jenkins-io-maven-cache"
+  description = "IAM policy for S3 access to ci_jenkins_io_maven_cache S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "MountpointFullBucketAccess",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket"
+        ],
+        Resource = [
+          aws_s3_bucket.ci_jenkins_io_maven_cache.arn,
+        ],
+      },
+      {
+        Sid    = "MountpointFullObjectAccess",
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:AbortMultipartUpload",
+          "s3:DeleteObject",
+        ],
+        Resource = [
+          "${aws_s3_bucket.ci_jenkins_io_maven_cache.arn}/*",
+        ],
+      },
+    ],
+  })
+}
+resource "aws_iam_role" "s3_ci_jenkins_io_maven_cache" {
+  name = "s3-ci-jenkins-io-maven-cache"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = module.cijenkinsio_agents_2.oidc_provider_arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringLike = {
+            "${replace(module.cijenkinsio_agents_2.cluster_oidc_issuer_url, "https://", "")}:sub" = "system:serviceaccount:kube-system:s3-csi-*",
+            "${replace(module.cijenkinsio_agents_2.cluster_oidc_issuer_url, "https://", "")}:aud" = "sts.amazonaws.com",
+          },
+        },
+      },
+    ],
+  })
+}
+resource "aws_iam_role_policy_attachment" "s3_role_attachment" {
+  policy_arn = aws_iam_policy.s3_ci_jenkins_io_maven_cache.arn
+  role       = aws_iam_role.s3_ci_jenkins_io_maven_cache.name
+}
+
+
+################################################################################################################################################################
+# EKS Cluster AWS resources for ci.jenkins.io agents-2
+################################################################################################################################################################
+resource "aws_kms_key" "cijenkinsio_agents_2" {
+  description         = "EKS Secret Encryption Key for the cluster cijenkinsio-agents-2"
+  enable_key_rotation = true
+
+  tags = merge(local.common_tags, {
+    associated_service = "eks/cijenkinsio-agents-2"
+  })
+}
+module "cijenkinsio_agents_2_ebscsi_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.54.1"
+
+  role_name             = "${module.cijenkinsio_agents_2.cluster_name}-ebs-csi"
+  attach_ebs_csi_policy = true
+  # Pass ARNs instead of IDs: https://github.com/terraform-aws-modules/terraform-aws-iam/issues/372
+  ebs_csi_kms_cmk_ids = [aws_kms_key.cijenkinsio_agents_2.arn]
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.cijenkinsio_agents_2.oidc_provider_arn
+      namespace_service_accounts = ["${local.cijenkinsio_agents_2["ebs-csi"]["namespace"]}:${local.cijenkinsio_agents_2["ebs-csi"]["serviceaccount"]}"]
+    }
+  }
+
+  tags = local.common_tags
+}
+module "cijenkinsio_agents_2_awslb_irsa_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.52.2"
+
+  role_name                              = "${module.cijenkinsio_agents_2.cluster_name}-awslb"
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.cijenkinsio_agents_2.oidc_provider_arn
+      namespace_service_accounts = ["${local.cijenkinsio_agents_2["awslb"]["namespace"]}:${local.cijenkinsio_agents_2["awslb"]["serviceaccount"]}"]
+    }
+  }
+
+  tags = local.common_tags
+}
+
+
+################################################################################
+# Karpenter Resources
+# - https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/karpenter-mng/
+# - https://karpenter.sh/v1.2/getting-started/getting-started-with-karpenter/
+################################################################################
+module "cijenkinsio_agents_2_karpenter" {
+  source  = "terraform-aws-modules/eks/aws//modules/karpenter"
+  version = "20.35.0"
+
+  # EC2_WINDOWS is a superset of EC2_LINUX to allow Windows nodes
+  access_entry_type = "EC2_WINDOWS"
+
+  cluster_name          = module.cijenkinsio_agents_2.cluster_name
+  enable_v1_permissions = true
+  namespace             = local.cijenkinsio_agents_2["karpenter"]["namespace"]
+
+  node_iam_role_use_name_prefix   = false
+  node_iam_role_name              = local.cijenkinsio_agents_2["karpenter"]["node_role_name"]
+  create_pod_identity_association = false # we use IRSA
+
+  enable_irsa                     = true
+  irsa_namespace_service_accounts = ["${local.cijenkinsio_agents_2["karpenter"]["namespace"]}:${local.cijenkinsio_agents_2["karpenter"]["serviceaccount"]}"]
+  irsa_oidc_provider_arn          = module.cijenkinsio_agents_2.oidc_provider_arn
+
+  node_iam_role_additional_policies = {
+    AmazonEC2ContainerRegistryReadOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+    additional                         = aws_iam_policy.ecrpullthroughcache.arn
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_iam_policy" "ecrpullthroughcache" {
+  name = "ECRPullThroughCache"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ecr:CreateRepository",
+          "ecr:BatchImportUpstreamImage",
+          "ecr:TagResource"
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+# https://karpenter.sh/docs/troubleshooting/#missing-service-linked-role
+resource "aws_iam_service_linked_role" "ec2_spot" {
+  aws_service_name = "spot.amazonaws.com"
+}
+################################################################################
+# Kubernetes resources in the EKS cluster ci.jenkins.io agents-2
+# Note: provider is defined in providers.tf but requires the eks-token below
+################################################################################
+data "aws_eks_cluster_auth" "cijenkinsio_agents_2" {
+  # Used by kubernetes/helm provider to authenticate to cluster with the AWS IAM identity (using a token)
+  name = module.cijenkinsio_agents_2.cluster_name
+}
+## Install AWS Load Balancer Controller
+resource "helm_release" "cijenkinsio_agents_2_awslb" {
+  provider         = helm.cijenkinsio_agents_2
+  name             = "aws-load-balancer-controller"
+  repository       = "https://aws.github.io/eks-charts"
+  chart            = "aws-load-balancer-controller"
+  version          = "1.12.0"
+  create_namespace = true
+  namespace        = local.cijenkinsio_agents_2["awslb"]["namespace"]
+
+  values = [yamlencode({
+    clusterName = module.cijenkinsio_agents_2.cluster_name,
+    serviceAccount = {
+      create = true,
+      name   = local.cijenkinsio_agents_2["awslb"]["serviceaccount"],
+      annotations = {
+        "eks.amazonaws.com/role-arn" = module.cijenkinsio_agents_2_awslb_irsa_role.iam_role_arn,
+      },
+    },
+    # We do not want to use ingress ALB class
+    createIngressClassResource = false,
+    nodeSelector               = module.cijenkinsio_agents_2.eks_managed_node_groups["applications"].node_group_labels,
+    tolerations                = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
+  })]
+}

--- a/helm/cluster-autoscaler-values.yaml.tfpl
+++ b/helm/cluster-autoscaler-values.yaml.tfpl
@@ -1,0 +1,23 @@
+---
+awsRegion: "${region}"
+
+nodeSelector:
+${yamlencode(nodeSelectors)}
+
+tolerations:
+${yamlencode(nodeTolerations)}
+
+extraArgs:
+  balance-similar-node-groups: true
+replicaCount: 2
+
+rbac:
+  create: true
+  serviceAccount:
+    name: "${serviceAccountName}"
+    annotations:
+      eks.amazonaws.com/role-arn: "${autoscalerRoleArn}"
+
+autoDiscovery:
+  enabled: true
+  clusterName: "${clusterName}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,6 +20,38 @@ resource "local_file" "jenkins_infra_data_report" {
           aws_security_group.unrestricted_out_http.name,
         ]
       },
+      "cijenkinsio-agents-2" = {
+        "cluster_endpoint"  = module.cijenkinsio_agents_2.cluster_endpoint,
+        "kubernetes_groups" = local.cijenkinsio_agents_2.kubernetes_groups,
+        "node_groups" = merge(
+          {
+            "applications" = {
+              "labels"      = module.cijenkinsio_agents_2.eks_managed_node_groups["applications"].node_group_labels
+              "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
+            }
+          },
+          { for knp in local.cijenkinsio_agents_2.karpenter_node_pools :
+            knp.name => {
+              "labels" = knp.nodeLabels,
+              "tolerations" = [for taint in knp.taints : {
+                "effect" : taint.effect,
+                "key" : taint.key,
+                "operator" : "Equal",
+                "value" : "true"
+              }]
+            }
+          },
+        )
+        artifact_caching_proxy = {
+          subnet_ids = local.cijenkinsio_agents_2.artifact_caching_proxy.subnet_ids,
+          ips        = local.cijenkinsio_agents_2.artifact_caching_proxy.ips,
+        },
+        docker_registry_mirror = {
+          subnet_ids = local.cijenkinsio_agents_2.docker_registry_mirror.subnet_ids,
+          ips        = local.cijenkinsio_agents_2.docker_registry_mirror.ips,
+        },
+        "subnet_ids" = [module.vpc.private_subnets[1], module.vpc.private_subnets[2], module.vpc.private_subnets[3]],
+      },
       artifacts_manager = {
         s3_bucket_name = aws_s3_bucket.ci_jenkins_io_artifacts.bucket
       },

--- a/providers.tf
+++ b/providers.tf
@@ -9,21 +9,3 @@ provider "aws" {
     tags = local.common_tags
   }
 }
-
-provider "kubernetes" {
-  alias = "cijenkinsio_agents_2"
-
-  host                   = module.cijenkinsio_agents_2.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
-  token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
-}
-
-provider "helm" {
-  alias = "cijenkinsio_agents_2"
-
-  kubernetes {
-    host                   = module.cijenkinsio_agents_2.cluster_endpoint
-    token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
-    cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
-  }
-}

--- a/providers.tf
+++ b/providers.tf
@@ -9,3 +9,21 @@ provider "aws" {
     tags = local.common_tags
   }
 }
+
+provider "kubernetes" {
+  alias = "cijenkinsio_agents_2"
+
+  host                   = module.cijenkinsio_agents_2.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
+}
+
+provider "helm" {
+  alias = "cijenkinsio_agents_2"
+
+  kubernetes {
+    host                   = module.cijenkinsio_agents_2.cluster_endpoint
+    token                  = data.aws_eks_cluster_auth.cijenkinsio_agents_2.token
+    cluster_ca_certificate = base64decode(module.cijenkinsio_agents_2.cluster_certificate_authority_data)
+  }
+}

--- a/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
@@ -1,0 +1,59 @@
+name: Bump EKS aws-ebs-csi-driver Addons versions in eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestAwsEbsCsiDriverVersion:
+    kind: shell
+    name: Retrieve the latest version of aws-ebs-csi-driver for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        aws eks describe-addon-versions \
+          --kubernetes-version {{ source "getClusterKubernetesVersion" }} \
+          --region us-east-2 \
+          --addon-name aws-ebs-csi-driver \
+          --query 'addons[0].addonVersions[0].addonVersion' \
+          --output text
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeAwsEbsCsiDriverVersion:
+    name: Update the aws-ebs-csi-driver addon version in eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestAwsEbsCsiDriverVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump EKS aws-ebs-csi-driver Addons versions to latest for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-addons

--- a/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
@@ -1,0 +1,59 @@
+name: Bump aws-mountpoint-s3-csi-driver add-on version (in cijenkinsio-agents-2)
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestAwsS3CsiDriverVersion:
+    kind: shell
+    name: Retrieve the latest version of aws-mountpoint-s3-csi-driver for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        aws eks describe-addon-versions \
+          --kubernetes-version {{ source "getClusterKubernetesVersion" }} \
+          --region us-east-2 \
+          --addon-name aws-mountpoint-s3-csi-driver \
+          --query 'addons[0].addonVersions[0].addonVersion' \
+          --output text
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeAwsS3CsiDriverVersion:
+    name: Update the aws-mountpoint-s3-csi-driver addon version in eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestAwsS3CsiDriverVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump aws-mountpoint-s3-csi-driver add-on version (in cijenkinsio-agents-2) to {{ source "getLatestAwsS3CsiDriverVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-addons

--- a/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
@@ -1,0 +1,59 @@
+name: Bump EKS Coredns Addons versions in eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestCoreDnsVersion:
+    kind: shell
+    name: Retrieve the latest version of coredns for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        aws eks describe-addon-versions \
+          --kubernetes-version {{ source "getClusterKubernetesVersion" }} \
+          --region us-east-2 \
+          --addon-name coredns \
+          --query 'addons[0].addonVersions[0].addonVersion' \
+          --output text
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeCoreDnsVersion:
+    name: Update the coredns addon version in eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestCoreDnsVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_cluster_addons_coredns_addon_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump EKS Coredns Addons versions to latest for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-addons

--- a/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
@@ -1,0 +1,59 @@
+name: Bump EKS kube-proxy Addons versions in eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestKubeProxyVersion:
+    kind: shell
+    name: Retrieve the latest version of kube-proxy for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        aws eks describe-addon-versions \
+          --kubernetes-version {{ source "getClusterKubernetesVersion" }} \
+          --region us-east-2 \
+          --addon-name kube-proxy \
+          --query 'addons[0].addonVersions[0].addonVersion' \
+          --output text
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeKubeProxyVersion:
+    name: Update the kube-proxy addon version in eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestKubeProxyVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump EKS kube-proxy Addons versions to latest for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-addons

--- a/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
@@ -1,0 +1,59 @@
+name: Bump EKS vpc-cni Addons versions in eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestVpcCniVersion:
+    kind: shell
+    name: Retrieve the latest version of vpc-cni for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        aws eks describe-addon-versions \
+          --kubernetes-version {{ source "getClusterKubernetesVersion" }} \
+          --region us-east-2 \
+          --addon-name vpc-cni \
+          --query 'addons[0].addonVersions[0].addonVersion' \
+          --output text
+      environments:
+          - name: PATH
+          - name: AWS_ACCESS_KEY_ID
+          - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeVpcCniVersion:
+    name: Update the vpc-cni addon version in eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVpcCniVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump EKS vpc-cni Addons versions to latest for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-addons

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -1,0 +1,62 @@
+name: Bump AMI release version for EKS managed node groups in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getClusterKubernetesVersion:
+    kind: hcl
+    name: Retrieve the Kubernetes version used in the EKS cluster
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.cluster_version
+
+  getLatestAmiReleaseVersion:
+    kind: shell
+    name: Retrieve the ami_release_version version for Kubernetes {{ source "getClusterKubernetesVersion" }}
+    dependson:
+      - getClusterKubernetesVersion
+    spec:
+      command: |
+        set -eux
+        release_version=$(aws ssm get-parameters-by-path \
+          --path "/aws/service/eks/optimized-ami/{{ source "getClusterKubernetesVersion" }}/" \
+          --recursive \
+          --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
+          --region us-east-2 \
+          --output json | jq -r '.[0] | fromjson | .release_version')
+        test -n "$release_version"
+        echo "$release_version"
+      environments:
+        - name: PATH
+        - name: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+
+targets:
+  upgradeAMIVersion:
+    name: Update the AMI release version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestAmiReleaseVersion
+    spec:
+      file: locals.tf
+      path: locals.cijenkinsio_agents_2_ami_release_version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump AMI release version for EKS managed node groups to {{ source "getLatestAmiReleaseVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - eks-ami-release

--- a/updatecli/updatecli.d/helm-charts/aws-lb-helm-release.yaml
+++ b/updatecli/updatecli.d/helm-charts/aws-lb-helm-release.yaml
@@ -1,0 +1,45 @@
+---
+name: Bump `aws-load-balancer-controller` helm release version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastChartVersion:
+    name: aws-load-balancer-controller Helm Chart Latest Version
+    kind: helmchart
+    spec:
+      url: https://aws.github.io/eks-charts
+      name: aws-load-balancer-controller
+      versionfilter:
+        kind: semver
+        strict: true
+
+targets:
+  updateChartVersion:
+    name: Update the helm release version for aws-load-balancer-controller
+    kind: hcl
+    sourceid: lastChartVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: resource.helm_release.cijenkinsio_agents_2_awslb.version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `aws-load-balancer-controller` helm chart version to {{ source "lastChartVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - aws-load-balancer-controller

--- a/updatecli/updatecli.d/helm-charts/karpenter-helm-release.yaml
+++ b/updatecli/updatecli.d/helm-charts/karpenter-helm-release.yaml
@@ -1,0 +1,55 @@
+---
+name: Bump `karpenter` helm release version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  # Logout step is required as described in Karpenter official documentation - https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#4-install-karpenter
+  logoutPublicECR:
+    name: Logout from public ECR registry via Helm CLI
+    kind: shell
+    spec:
+      command: |
+        docker logout public.ecr.aws
+
+  lastChartVersion:
+    name: Karpenter AWS Provider Helm Chart Latest Version
+    dependson:
+      - logoutPublicECR
+    kind: helmchart
+    spec:
+      url: oci://public.ecr.aws/karpenter
+      name: karpenter
+      versionfilter:
+        kind: semver
+        strict: true
+
+targets:
+  updateChartVersion:
+    name: Update the helm release version for karpenter
+    kind: hcl
+    sourceid: lastChartVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: resource.helm_release.cijenkinsio_agents_2_karpenter.version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump `karpenter` helm chart version to {{ source "lastChartVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - karpenter

--- a/updatecli/updatecli.d/terraform-modules/eks.yaml
+++ b/updatecli/updatecli.d/terraform-modules/eks.yaml
@@ -1,4 +1,4 @@
-name: Bump version of the Terraform "ecr" module in terraform-aws-sponsorship/ecr.tf
+name: Bump version of the Terraform "eks" module
 
 scms:
   default:
@@ -14,30 +14,30 @@ scms:
 
 sources:
   getLatestVersion:
-    name: Get latest version of terraform-aws-modules/ecr/aws
+    name: Get latest version of terraform-aws-modules/eks/aws
     kind: terraform/registry
     spec:
       type: module
       namespace: terraform-aws-modules
-      name: ecr
+      name: eks
       targetsystem: aws
 
 targets:
   updateModule:
-    name: Update the Terraform "ecr" module version in terraform-aws-sponsorship/ecr.tf
+    name: Update the Terraform "eks" module version
     kind: hcl
     sourceid: getLatestVersion
     spec:
-      file: ecr.tf
-      path: module.ecr.version
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2.version
     scmid: default
 
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump version of the AWS Terraform module "ecr" to {{ source "getLatestVersion" }}
+    title: Bump version of the AWS Terraform module "eks" to {{ source "getLatestVersion" }}
     spec:
       labels:
         - dependencies
-        - terraform-aws-ecr-module
+        - terraform-aws-eks-module

--- a/updatecli/updatecli.d/terraform-modules/irsa-role.yaml
+++ b/updatecli/updatecli.d/terraform-modules/irsa-role.yaml
@@ -1,0 +1,43 @@
+name: Bump version of the Terraform "irsa_role" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestVersion:
+    kind: terraform/registry
+    name: Retrieve the latest version
+    spec:
+      type: module
+      namespace: terraform-aws-modules
+      name: iam
+      targetsystem: aws
+
+targets:
+  upgradeEbsCsiModuleVersion:
+    name: Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2_ebscsi_irsa_role.version
+    scmid: default
+
+actions:
+  upgradeAwsIamModuleVersion:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_autoscaler_irsa_role" and "cijenkinsio_agents_2_ebscsi_irsa_role" to {{ source "getLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-iam-role-module

--- a/updatecli/updatecli.d/terraform-modules/irsa-role.yaml
+++ b/updatecli/updatecli.d/terraform-modules/irsa-role.yaml
@@ -23,7 +23,7 @@ sources:
       targetsystem: aws
 
 targets:
-  upgradeEbsCsiModuleVersion:
+  updateModule:
     name: Update the Terraform "cijenkinsio_agents_2_ebscsi_irsa_role" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
     kind: hcl
     sourceid: getLatestVersion

--- a/updatecli/updatecli.d/terraform-modules/karpenter.yaml
+++ b/updatecli/updatecli.d/terraform-modules/karpenter.yaml
@@ -1,0 +1,43 @@
+name: Bump version of the Terraform "karpenter" module in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getLatestVersion:
+    kind: terraform/registry
+    name: Retrieve the latest version
+    spec:
+      type: module
+      namespace: terraform-aws-modules
+      name: eks
+      targetsystem: aws
+
+targets:
+  upgradeKarpenterModuleVersion:
+    name: Update the Terraform "cijenkinsio_agents_2_karpenter" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+    kind: hcl
+    sourceid: getLatestVersion
+    spec:
+      file: eks-cijenkinsio-agents-2.tf
+      path: module.cijenkinsio_agents_2_karpenter.version
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump version of the AWS Terraform module "cijenkinsio_agents_2_karpenter" to {{ source "getLatestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - terraform-aws-eks-karpenter-module

--- a/updatecli/updatecli.d/terraform-modules/karpenter.yaml
+++ b/updatecli/updatecli.d/terraform-modules/karpenter.yaml
@@ -23,7 +23,7 @@ sources:
       targetsystem: aws
 
 targets:
-  upgradeKarpenterModuleVersion:
+  updateModule:
     name: Update the Terraform "cijenkinsio_agents_2_karpenter" module version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
     kind: hcl
     sourceid: getLatestVersion

--- a/updatecli/updatecli.d/terraform-providers/helm.yaml
+++ b/updatecli/updatecli.d/terraform-providers/helm.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `helm` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `helm` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: helm
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/helm
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `helm` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/helm

--- a/updatecli/updatecli.d/terraform-providers/helm.yaml
+++ b/updatecli/updatecli.d/terraform-providers/helm.yaml
@@ -20,6 +20,11 @@ sources:
       type: provider
       namespace: hashicorp
       name: helm
+      versionfilter:
+        kind: semver
+        # Until https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3386 is fixed
+        pattern: "~2"
+        strict: true
 
 targets:
   updateTerraformLockFile:

--- a/updatecli/updatecli.d/terraform-providers/kubernetes.yaml
+++ b/updatecli/updatecli.d/terraform-providers/kubernetes.yaml
@@ -1,0 +1,47 @@
+name: "Bump Terraform `kubernetes` provider version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    name: Get latest version of the `kubernetes` provider
+    kind: terraform/registry
+    spec:
+      type: provider
+      namespace: hashicorp
+      name: kubernetes
+
+targets:
+  updateTerraformLockFile:
+    name: Update Terraform lock file
+    kind: terraform/lock
+    sourceid: lastVersion
+    spec:
+      file: .terraform.lock.hcl
+      provider: hashicorp/kubernetes
+      platforms:
+        - linux_amd64
+        - linux_arm64
+        - darwin_amd64
+        - darwin_arm64
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      title: Bump Terraform `kubernetes` provider version to {{ source "lastVersion" }}
+      labels:
+        - terraform-providers
+        - hashicorp/time

--- a/versions.tf
+++ b/versions.tf
@@ -33,6 +33,8 @@ terraform {
     # Required by the EKS module
     helm = {
       source = "hashicorp/helm"
+      # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3383#issuecomment-2987712505
+      version = "~> 2"
     }
     # Required by the secrets-manager module
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -14,6 +14,26 @@ terraform {
     cloudinit = {
       source = "hashicorp/cloudinit"
     }
+    # Required by the EKS module
+    null = {
+      source = "hashicorp/null"
+    }
+    # Required by the EKS module
+    time = {
+      source = "hashicorp/time"
+    }
+    # Required by the EKS module
+    tls = {
+      source = "hashicorp/tls"
+    }
+    # Required by the EKS module
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    # Required by the EKS module
+    helm = {
+      source = "hashicorp/helm"
+    }
     # Required by the secrets-manager module
     random = {
       source = "hashicorp/random"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4688

- Reverts #212 (partially)
- Bump modules version to latest available
- Pin helm provider version to 2.x 

