### PR TITLE
bump EKS to 1.31

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -2,13 +2,12 @@
 # EKS Cluster ci.jenkins.io agents-2 definition
 ################################################################################
 module "cijenkinsio_agents_2" {
-  source = "terraform-aws-modules/eks/aws"
-  # TODO: track with updatecli
+  source  = "terraform-aws-modules/eks/aws"
   version = "20.37.1"
 
   cluster_name = "cijenkinsio-agents-2"
   # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-  cluster_version = "1.30"
+  cluster_version = "1.31"
   create_iam_role = true
 
   # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets

--- a/locals.tf
+++ b/locals.tf
@@ -16,9 +16,7 @@ locals {
   cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version       = "v1.30.9-eksbuild.3"
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version          = "v1.19.3-eksbuild.1"
   cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version = "v1.41.0-eksbuild.1"
-  ## TODO track with updatecli
-  # aws eks describe-addon-versions --profile=jenkins-infra-developer --region=us-east-2 --kubernetes-version="1.30" --addon-name="aws-mountpoint-s3-csi-driver" --query 'addons[0].addonVersions[0].addonVersion' --output text
-  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version = "v1.13.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version  = "v1.13.0-eksbuild.1"
 
   cijenkinsio_agents_2_ami_release_version = "1.30.9-20250403"
 


### PR DESCRIPTION
Note: only the cluster. We expect `updatecli` to update further tools.

Terraform disabled for this one.