### PR TITLE
hotfix(eks-cijenkinsio-agents-2) ensure IMDS works with 2 hops to allow our LB to work with IRSA

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -153,6 +153,10 @@ module "cijenkinsio_agents_2" {
         }
       }
 
+      metadata_options {
+        http_put_response_hop_limit = 2
+      }
+
       iam_role_additional_policies = {
         AmazonEC2ContainerRegistryReadOnly = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
         additional                         = aws_iam_policy.ecrpullthroughcache.arn

--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -153,8 +153,12 @@ module "cijenkinsio_agents_2" {
         }
       }
 
-      metadata_options {
+      metadata_options = {
         http_put_response_hop_limit = 2
+      }
+
+      monitoring = {
+        enabled = true
       }
 
       iam_role_additional_policies = {


### PR DESCRIPTION
Fixup of #311 which sets up pod identity by default, which requires only 1 network hop to get the IMDS.

But our AWSLB system is still using IRSA and requries 2 hops as such