### PR TITLE
feat(vpc) increase subnets sizing for our usages

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -64,7 +64,9 @@ locals {
         },
       ],
       # Only 1 subnet in 1 AZ (for EBS)
-      subnet_ids = [for idx, subnet in local.vpc_private_subnets : module.vpc.private_subnets[idx] if(startswith(subnet.name, "eks") && subnet.az == local.agents_availability_zone)]
+      subnet_ids = [
+        for idx, subnet in local.vpc_private_subnets : module.vpc.private_subnets[idx] if subnet.name == "eks-1"
+      ]
     }
     karpenter_node_pools = [
       {
@@ -178,10 +180,10 @@ locals {
   # Public subnets use the second partition of the vpc_cidr (index 1)
   vpc_private_subnets = [
     {
-      name = "vm-agents-1",
-      az   = format("${local.region}%s", "b"),
-      # A /23 (the '6' integer argument) on the second subset of the VPC (split in 2)
-      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 0)
+      name = "eks-3",
+      az   = local.agents_availability_zone,
+      # A /21 (the '4' integer argument) on the second subset of the VPC (split in 2)
+      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 4, 4)
     },
     {
       name = "eks-1",
@@ -199,7 +201,7 @@ locals {
       name = "vm-agents-2",
       az   = local.agents_availability_zone,
       # A /23 (the '6' integer argument) on the second subset of the VPC (split in 2)
-      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 6, 3)
+      cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 4, 3)
     },
   ]
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -21,13 +21,18 @@ module "vpc" {
   manage_default_route_table    = false
   manage_default_security_group = false
 
-  azs = [for subnet_index, subnet_data in local.vpc_private_subnets : subnet_data.az]
+  azs = [
+    format("${local.region}%s", "b"),
+    format("${local.region}%s", "a"),
+    format("${local.region}%s", "c"),
+    format("${local.region}%s", "a"),
+  ]
+  #sort(distinct([for subnet_index, subnet_data in local.vpc_private_subnets : subnet_data.az]))
 
   private_subnets      = [for subnet in local.vpc_private_subnets : subnet.cidr]
   private_subnet_names = [for subnet in local.vpc_private_subnets : subnet.name]
   private_subnet_tags  = local.common_tags
 
-  create_private_nat_gateway_route = true
 
   public_subnets      = [for subnet in local.vpc_public_subnets : subnet.cidr]
   public_subnet_names = [for subnet in local.vpc_public_subnets : subnet.name]
@@ -35,10 +40,12 @@ module "vpc" {
 
   public_subnet_ipv6_prefixes = range(length(local.vpc_public_subnets))
 
-  # One NAT gateway per subnet (default)
-  # ref. https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-subnet-default
-  enable_nat_gateway = true
-  single_nat_gateway = false
+  # One NAT gateway per AZ. Has requirements which needs to be checked: https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#one-nat-gateway-per-availability-zone
+  enable_nat_gateway               = true
+  single_nat_gateway               = false
+  one_nat_gateway_per_az           = false
+  create_private_nat_gateway_route = true
+  create_vpc                       = true
 
   enable_dns_hostnames = true
 }


### PR DESCRIPTION
- Replace unused `vm-agents-1` subnet by a bigger `eks-3` (to be added to EKS later for agents)
- Increase size of `vm-agents-2` subnet`

Ref. https://github.com/jenkins-infra/helpdesk/issues/4768#issuecomment-3242434792


=> since the `vpc` module is a mess, I avoided the "one NAT gateway per AZ" otherwise we'll have to re-create all subnets, VMs, cluster, etc..

In this PR, I'm trying to replace the old (unused) `vm-agents-1` by an `eks-3` (partially reverting #321) with a `/21` sizing.
Also, increasing the size of `vm-agents-1` to `/21` will also help to avoid hitting limits when the EC2 plugin is "overallocating"