### PR TITLE
feat(ci.jenkins.io-agents-2) bump EKS from 1.31 to 1.32

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -7,7 +7,7 @@ module "cijenkinsio_agents_2" {
 
   name = "cijenkinsio-agents-2"
   # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-  kubernetes_version = "1.31"
+  kubernetes_version = "1.32"
   create_iam_role    = true
 
   # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets
@@ -124,7 +124,9 @@ module "cijenkinsio_agents_2" {
       service_account_role_arn    = aws_iam_role.s3_ci_jenkins_io_maven_cache.arn
       resolve_conflicts_on_create = "OVERWRITE"
     },
-    eks-pod-identity-agent = {},
+    eks-pod-identity-agent = {
+      addon_version = local.cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version
+    },
   }
 
   eks_managed_node_groups = {

--- a/locals.tf
+++ b/locals.tf
@@ -12,13 +12,14 @@ locals {
     controller_vm_fqdn = "aws.ci.jenkins.io"
   }
 
-  cijenkinsio_agents_2_cluster_addons_coredns_addon_version         = "v1.11.4-eksbuild.22"
-  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version       = "v1.31.10-eksbuild.12"
-  cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version          = "v1.20.3-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version = "v1.48.0-eksbuild.2"
-  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version  = "v1.15.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_coredns_addon_version             = "v1.11.4-eksbuild.22"
+  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.32.6-eksbuild.12"
+  cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.20.3-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.48.0-eksbuild.2"
+  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v1.15.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.8-eksbuild.2"
 
-  cijenkinsio_agents_2_ami_release_version = "1.31.13-20250920"
+  cijenkinsio_agents_2_ami_release_version = "1.32.9-20250920"
 
   cijenkinsio_agents_2 = {
     # TODO: where does the values come from?


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4817

This PR bumps the EKS cluster to 1.32. It also bumps the associated resources (AMI versions for nodes, and addons).
As part of this change, the addon `eks-pod-identity-agent` now has its version fixed (and will have to track it on a further PR).

----

Note: I ran the following commands to retrieve the addon and AMI versions:

```
aws ssm get-parameters-by-path \
          --path "/aws/service/eks/optimized-ami/1.32/" \
          --recursive \
          --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
          --region us-east-2 \
          --profile=terraform-admin \
          --output json | jq -r '.[0] | fromjson | .release_version'
1.32.9-20250920

aws eks describe-addon-versions \
          --kubernetes-version 1.32 \
          --region us-east-2 \
          --profile=terraform-admin \
          --addon-name kube-proxy \
          --query 'addons[0].addonVersions[0].addonVersion' \
          --output text
v1.32.6-eksbuild.12

aws eks describe-addon-versions \
          --kubernetes-version 1.32 \
          --region us-east-2 \
          --profile=terraform-admin \
          --addon-name coredns \
          --query 'addons[0].addonVersions[0].addonVersion' \
          --output text
v1.11.4-eksbuild.22

aws eks describe-addon-versions \
          --kubernetes-version 1.32 \
          --region us-east-2 \
          --profile=terraform-admin \
          --addon-name vpc-cni \
          --query 'addons[0].addonVersions[0].addonVersion' \
          --output text
v1.20.3-eksbuild.1

aws eks describe-addon-versions \
          --kubernetes-version 1.32 \
          --region us-east-2 \
          --profile=terraform-admin \
          --addon-name aws-ebs-csi-driver \
          --query 'addons[0].addonVersions[0].addonVersion' \
          --output text
v1.48.0-eksbuild.2

aws eks describe-addon-versions \
          --kubernetes-version 1.32 \
          --region us-east-2 \
          --profile=terraform-admin \
          --addon-name eks-pod-identity-agent \
          --query 'addons[0].addonVersions[0].addonVersion' \
          --output text
```