### PR TITLE
chore(eks-cijenkinsioagents2) Switch inline policy for karpenter modue to avoid `LimitExceeded: Cannot exceed quota for PolicySize: 6144`

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -504,6 +504,7 @@ module "cijenkinsio_agents_2_karpenter" {
   cluster_name = module.cijenkinsio_agents_2.cluster_name
   namespace    = local.cijenkinsio_agents_2["karpenter"]["namespace"]
 
+  enable_inline_policy            = true
   node_iam_role_use_name_prefix   = false
   node_iam_role_name              = local.cijenkinsio_agents_2["karpenter"]["node_role_name"]
   create_pod_identity_association = true


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/485, following https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3512#issuecomment-3453472073