### PR TITLE
chore(all VMs) ignore user_data changes

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -141,6 +141,13 @@ resource "aws_instance" "ci_jenkins_io" {
     local.common_tags,
     { "Name" = "ci-jenkins-io" }
   )
+
+  lifecycle {
+    ignore_changes = [
+      # Ignoring user_data in case we make changes to the tpl file (which could lead to destroying VMs inadvertently).
+      user_data,
+    ]
+  }
 }
 
 ## SSH Key used to access EC2 Agents (private key stored encrypted in SOPS)


### PR DESCRIPTION
We don't want to risk destroying VMs when an harmless change is pushed to the "common" `cloudinit.tftpl` file in jenkins-infra/shared-tools, but we want to always have an up to date cloud init template (when creating/recreating a VM) to benefit from latest changes.

This PR is a sustainable fix, but we can think of other techniques in the future (updatecli to retrieve the file from shared-tools so a PR would always be opened with a proper Terraform plan for instance)

----

Tested with the code in https://github.com/jenkins-infra/shared-tools/pull/175 which do not specify any change