### PR TITLE
chore: add get-addon-versions.sh helper script

### DIFF
--- a/get-addon-versions.sh
+++ b/get-addon-versions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+
+# This script retrieves addons and AMI version corresponding to a Kubernetes version.
+
+AWS_REGION="${AWS_REGION:-us-east-2}"
+AWS_PROFILE="${AWS_PROFILE:-jenkins-infra-admin}"
+ADDONS="${ADDONS:-coredns kube-proxy vpc-cni aws-ebs-csi-driver aws-mountpoint-s3-csi-driver eks-pod-identity-agent}"
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $0 <kubernetes-version>"
+  echo "Example: $0 1.34"
+  exit 1
+fi
+
+k8s_version="$1"
+
+echo "Using Kubernetes version: ${k8s_version}"
+echo
+
+get_addon_version() {
+  addon_name="$1"
+
+  aws eks describe-addon-versions \
+    --kubernetes-version "${k8s_version}" \
+    --region "${AWS_REGION}" \
+    --profile "${AWS_PROFILE}" \
+    --addon-name "${addon_name}" \
+    --query 'addons[0].addonVersions[0].addonVersion' \
+    --output text
+}
+
+echo "Fetching addon versions..."
+for addon in ${ADDONS}; do
+  version=$(get_addon_version "${addon}")
+  printf "%-35s %s\n" "${addon}:" "${version}"
+done
+
+echo "Fetching EKS optimized AMI release version..."
+ami_release_version=$(
+  aws ssm get-parameters-by-path \
+    --path "/aws/service/eks/optimized-ami/${k8s_version}/" \
+    --recursive \
+    --query "Parameters[?contains(Name, 'amazon-linux-2023/arm64/standard/recommended')].Value" \
+    --region "${AWS_REGION}" \
+    --profile "${AWS_PROFILE}" \
+    --output json |
+  jq -r '.[0] | fromjson | .release_version'
+)
+
+echo "AMI release version: ${ami_release_version}"

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,7 @@ locals {
     controller_vm_fqdn = "aws.ci.jenkins.io"
   }
 
+  # Run `./get-addon-versions.sh <k8s-version>` to obtain the versions corresponding to a new Kubernetes version
   cijenkinsio_agents_2_cluster_addons_coredns_addon_version             = "v1.13.2-eksbuild.10"
   cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.33.10-eksbuild.11"
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.22.1-eksbuild.2"


### PR DESCRIPTION
Commands listed in https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/420 extracted to a small helper script.

Related:
- https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4591283155

### Testing done

```bash
$ export AWS_SECRET_ACCESS_KEY="$(security find-generic-password -a aws-jenkins-hlemeur-secret-key -w)";export AWS_ACCESS_KEY_ID="<my-access-key-id>";
$ ./get-addon-versions.sh 1.34
```

<details><summary>output:</summary>

```
+ AWS_REGION=us-east-2
+ AWS_PROFILE=terraform-admin
+ ADDONS='coredns kube-proxy vpc-cni aws-ebs-csi-driver aws-mountpoint-s3-csi-driver eks-pod-identity-agent'
+ [[ 1 -ne 1 ]]
+ k8s_version=1.34
+ echo 'Using Kubernetes version: 1.34'
Using Kubernetes version: 1.34
+ echo

+ echo 'Fetching addon versions...'
Fetching addon versions...
+ for addon in ${ADDONS}
++ get_addon_version coredns
++ addon_name=coredns
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name coredns --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v1.13.2-eksbuild.10
+ printf '%-35s %s\n' coredns: v1.13.2-eksbuild.10
coredns:                            v1.13.2-eksbuild.10
+ for addon in ${ADDONS}
++ get_addon_version kube-proxy
++ addon_name=kube-proxy
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name kube-proxy --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v1.34.6-eksbuild.11
+ printf '%-35s %s\n' kube-proxy: v1.34.6-eksbuild.11
kube-proxy:                         v1.34.6-eksbuild.11
+ for addon in ${ADDONS}
++ get_addon_version vpc-cni
++ addon_name=vpc-cni
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name vpc-cni --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v1.22.1-eksbuild.2
+ printf '%-35s %s\n' vpc-cni: v1.22.1-eksbuild.2
vpc-cni:                            v1.22.1-eksbuild.2
+ for addon in ${ADDONS}
++ get_addon_version aws-ebs-csi-driver
++ addon_name=aws-ebs-csi-driver
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name aws-ebs-csi-driver --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v1.60.1-eksbuild.1
+ printf '%-35s %s\n' aws-ebs-csi-driver: v1.60.1-eksbuild.1
aws-ebs-csi-driver:                 v1.60.1-eksbuild.1
+ for addon in ${ADDONS}
++ get_addon_version aws-mountpoint-s3-csi-driver
++ addon_name=aws-mountpoint-s3-csi-driver
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name aws-mountpoint-s3-csi-driver --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v2.5.0-eksbuild.1
+ printf '%-35s %s\n' aws-mountpoint-s3-csi-driver: v2.5.0-eksbuild.1
aws-mountpoint-s3-csi-driver:       v2.5.0-eksbuild.1
+ for addon in ${ADDONS}
++ get_addon_version eks-pod-identity-agent
++ addon_name=eks-pod-identity-agent
++ aws eks describe-addon-versions --kubernetes-version 1.34 --region us-east-2 --profile terraform-admin --addon-name eks-pod-identity-agent --query 'addons[0].addonVersions[0].addonVersion' --output text
+ version=v1.3.10-eksbuild.3
+ printf '%-35s %s\n' eks-pod-identity-agent: v1.3.10-eksbuild.3
eks-pod-identity-agent:             v1.3.10-eksbuild.3
+ echo 'Fetching EKS optimized AMI release version...'
Fetching EKS optimized AMI release version...
++ aws ssm get-parameters-by-path --path /aws/service/eks/optimized-ami/1.34/ --recursive --query 'Parameters[?contains(Name, '\''amazon-linux-2023/arm64/standard/recommended'\'')].Value' --region us-east-2 --profile terraform-admin --output json
++ jq -r '.[0] | fromjson | .release_version'
+ ami_release_version=1.34.8-20260527
+ echo 'AMI release version: 1.34.8-20260527'
AMI release version: 1.34.8-20260527
```

</details>