### PR TITLE
feat: upgrade `cijioagents2` and its addons to Kubernetes 1.34

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -7,7 +7,7 @@ module "cijenkinsio_agents_2" {
 
   name = "cijenkinsio-agents-2"
   # Kubernetes version in format '<MINOR>.<MINOR>', as per https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
   create_iam_role    = true
 
   # 2 AZs are mandatory for EKS https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html#network-requirements-subnets

--- a/locals.tf
+++ b/locals.tf
@@ -13,13 +13,13 @@ locals {
   }
 
   cijenkinsio_agents_2_cluster_addons_coredns_addon_version             = "v1.13.2-eksbuild.10"
-  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.33.10-eksbuild.11"
+  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.34.6-eksbuild.11"
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.22.1-eksbuild.2"
-  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.60.0-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v1.15.0-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.10-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.60.1-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v2.5.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.10-eksbuild.3"
 
-  cijenkinsio_agents_2_ami_release_version = "1.33.11-20260527"
+  cijenkinsio_agents_2_ami_release_version = "1.34.8-20260527"
 
   cijenkinsio_agents_2 = {
     # TODO: where does the values come from?


### PR DESCRIPTION
Addons and AMI versions obtained with the script from https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/515.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4908#issuecomment-4591283155