### PR TITLE
fix(cijenkinsio_agents_2) revert CSI S3 addon version

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -16,7 +16,7 @@ locals {
   cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.34.6-eksbuild.11"
   cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.22.1-eksbuild.2"
   cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.60.1-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v2.5.0-eksbuild.1"
+  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v1.15.0-eksbuild.1"
   cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.10-eksbuild.3"
 
   cijenkinsio_agents_2_ami_release_version = "1.34.8-20260527"


### PR DESCRIPTION
Fixup of #516 (the script proposed in #515 also upgraded the CSI S3 addon version while it's blocked - ref. https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/364#pullrequestreview-3293883737).