### PR TITLE
chore: replace `var.terratest` usages with `var.environment`

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -629,7 +629,7 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_node_pools" {
   ## Disable this resource when running in terratest
   # to avoid errors such as "cannot create REST client: no client config"
   # or "The credentials configured in the provider block are not accepted by the API server. Error: Unauthorized"
-  for_each = var.terratest ? {} : {
+  for_each = var.environment == "staging" ? {} : {
     for index, knp in local.cijenkinsio_agents_2.karpenter_node_pools : knp.name => knp
   }
 
@@ -714,7 +714,7 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
   ## Disable this resource when running in terratest
   # to avoid errors such as "cannot create REST client: no client config"
   # or "The credentials configured in the provider block are not accepted by the API server. Error: Unauthorized"
-  for_each = var.terratest ? {} : {
+  for_each = var.environment == "staging" ? {} : {
     for index, knp in local.cijenkinsio_agents_2.karpenter_node_pools : knp.name => knp
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,14 +9,7 @@ variable "aws_profile" {
   description = "AWS CLI profile to use with terraform"
 }
 
-variable "outbound_ip_count" {
-  type        = number
-  description = "Number of outbound IPs to use."
-  default     = 2
-}
-
-variable "terratest" {
-  type        = bool
-  description = "value"
-  default     = false
+variable "environment" {
+  type    = string
+  default = "staging"
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5169#issuecomment-4623739437