### PR TITLE
fix(eks-cijenkinsio-agents-2) Karpenter Node pools are either Spot or OnDemand

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -666,10 +666,9 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_node_pools" {
               key      = "karpenter.sh/capacity-type"
               operator = "In"
 
-              values = compact([
-                lookup(each.value, "spot", false) ? "spot" : "",
-                "on-demand",
-              ])
+              values = [
+                lookup(each.value, "spot", false) ? "spot" : "on-demand",
+              ]
             },
             {
               key      = "karpenter.k8s.aws/instance-family"


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5172#issuecomment-4742802845