### PR TITLE
feat(ci.jenkins.io) add ASGs for all Windows Spot EC2 agents workloads

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -4,11 +4,13 @@ terraform(
     string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'staging-terraform-aws-sponsorship-access-key'),
     string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'staging-terraform-aws-sponsorship-secret-key'),
     string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-aws-sponsorship-backend-config-arm-secret'),
+    string(variable: 'TF_VAR_ci_jenkins_io_datadog_api_key', credentialsId:'ci-jenkins-io-ephemeral-agents-datadog-api-key'),
   ],
   productionCredentials: [
     string(variable: 'AWS_ACCESS_KEY_ID', credentialsId: 'production-terraform-aws-sponsorship-access-key'),
     string(variable: 'AWS_SECRET_ACCESS_KEY', credentialsId:'production-terraform-aws-sponsorship-secret-key'),
     string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'production-terraform-aws-sponsorship-backend-config-arm-secret'),
+    string(variable: 'TF_VAR_ci_jenkins_io_datadog_api_key', credentialsId:'ci-jenkins-io-ephemeral-agents-datadog-api-key'),
   ],
   publishReports: ['jenkins-infra-data-reports/aws-sponsorship.json'],
 )

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -33,12 +33,6 @@ resource "aws_iam_instance_profile" "ci_jenkins_io" {
   name = "ci-jenkins-io"
   role = aws_iam_role.ci_jenkins_io.name
 }
-resource "aws_iam_role_policy" "ci_jenkins_io_ec2_agents" {
-  name = "ci-jenkins-io-ec2-agents"
-  role = aws_iam_role.ci_jenkins_io.id
-
-  policy = data.aws_iam_policy_document.jenkins_ec2_agents.json
-}
 # Permissions required by ECR (to allow using pull through after "aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <account ID>.dkr.ecr.<region>.amazonaws.com")
 resource "aws_iam_role_policy_attachment" "ci_jenkins_io_read_ecr" {
   # AmazonEC2ContainerRegistryReadOnly
@@ -84,6 +78,91 @@ data "aws_iam_policy_document" "jenkins_ec2_agents" {
     # tfsec:ignore:AWS099
     resources = ["*"]
   }
+}
+resource "aws_iam_role_policy" "ci_jenkins_io_ec2_agents" {
+  name = "ci-jenkins-io-ec2-agents"
+  role = aws_iam_role.ci_jenkins_io.id
+
+  policy = data.aws_iam_policy_document.jenkins_ec2_agents.json
+}
+# Permissions required by Jenkins EC2 Fleet plugin in https://plugins.jenkins.io/ec2-fleet/#plugin-content-3-configure-user-permissions
+data "aws_iam_policy_document" "jenkins_ec2_fleet_agents" {
+  statement {
+    sid    = "jenkinsEC2FleetEC2"
+    effect = "Allow"
+
+    actions = [
+      "ec2:CreateTags",
+      "ec2:DescribeFleetInstances",
+      "ec2:DescribeFleets",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeRegions",
+      "ec2:DescribeSpotFleetInstances",
+      "ec2:DescribeSpotFleetRequests",
+      "ec2:ModifyFleet",
+      "ec2:ModifySpotFleetRequest",
+      "ec2:TerminateInstances",
+    ]
+    ## We allow all resources names
+    # tfsec:ignore:AWS099
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "jenkinsEC2FleetAutoscaling"
+    effect = "Allow"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:UpdateAutoScalingGroup",
+    ]
+    ## We allow all resources names
+    # tfsec:ignore:AWS099
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "jenkinsEC2FleetIAM"
+    effect = "Allow"
+
+    actions = [
+      "iam:ListInstanceProfiles",
+      "iam:ListRoles",
+    ]
+    ## We allow all resources names
+    # tfsec:ignore:AWS099
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "jenkinsEC2FleetIAMPassRole"
+    effect = "Allow"
+
+    actions = [
+      "iam:PassRole",
+    ]
+    ## We allow all resources names
+    # tfsec:ignore:AWS099
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+
+      values = [
+        "ec2.amazonaws.com",
+        "ec2.amazonaws.com.cn",
+      ]
+    }
+  }
+}
+resource "aws_iam_role_policy" "ci_jenkins_io_ec2_fleet" {
+  name = "ci-jenkins-io-ec2-fleet"
+  role = aws_iam_role.ci_jenkins_io.id
+
+  policy = data.aws_iam_policy_document.jenkins_ec2_fleet_agents.json
 }
 
 ### Compute Resources
@@ -279,6 +358,139 @@ data "aws_iam_policy_document" "ci_jenkins_io_artifacts_objects" {
 ####################################################################################
 # ci.jenkins.io EC2 agents resources
 ####################################################################################
+resource "aws_launch_template" "ci_jenkins_io_ec2_agents" {
+  for_each = local.agent_definitions
+
+  name = "ci-jenkins-io-${each.key}"
+  # No instance_type here: overridden by the ASG mixed_instances_policy
+  image_id      = each.value.ami_id
+  ebs_optimized = true
+  key_name      = aws_key_pair.deployer.key_name
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.ci_jenkins_io_ec2_agents.name
+  }
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups = [
+      aws_security_group.ephemeral_vm_agents.id,
+      aws_security_group.unrestricted_out_http.id,
+    ]
+    delete_on_termination = true
+  }
+
+  # Root OS disk — 150 GB matches osDiskSize in hieradata common.yaml.
+  block_device_mappings {
+    device_name = "/dev/sda1"
+    ebs {
+      volume_size           = 150
+      volume_type           = "gp3"
+      encrypted             = true
+      delete_on_termination = true
+    }
+  }
+
+  # IMDSv2 required (matches metadataTokensRequired: true in the EC2 plugin config).
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  user_data = local.user_data[each.key]
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = merge(local.common_tags, {
+      "Name"         = "ci-jenkins-io-${each.key}"
+      "architecture" = each.value.architecture
+      "os"           = each.value.os
+    })
+  }
+
+  tag_specifications {
+    resource_type = "volume"
+    tags = merge(local.common_tags, {
+      "Name" = "ci-jenkins-io-${each.key}"
+    })
+  }
+
+  tags = merge(local.common_tags, {
+    "Name" = "ci-jenkins-io-${each.key}"
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+resource "aws_autoscaling_group" "ci_jenkins_io_ec2_agents" {
+  for_each = local.agent_definitions
+
+  name = "ci-jenkins-io-spot-${each.key}"
+
+  ## The EC2 Fleet plugin manages desired_capacity; we set it to 0 here so no
+  ## instances are launched before Jenkins is wired up.
+  ## min/max are advisory defaults; the plugin enforces its own minSize/maxSize.
+  min_size         = 0
+  max_size         = each.value.max_size
+  desired_capacity = 0
+
+  vpc_zone_identifier = [
+    for idx, subnet in local.vpc_private_subnets :
+    module.vpc.private_subnets[idx] if contains([
+      "eks-3",      # us-east-2a
+      "us-east-2b", # us-east-2b
+      "eks-2",      # us-east-2c
+      ],
+    subnet.name)
+  ]
+
+  # Delegate all instance management to the EC2 Fleet plugin. Skip default cooldowns.
+  default_cooldown          = 0
+  health_check_type         = "EC2"
+  health_check_grace_period = 0
+
+  mixed_instances_policy {
+    instances_distribution {
+      # All capacity from spot
+      on_demand_base_capacity                  = 0
+      on_demand_percentage_above_base_capacity = 0
+      # price-capacity-optimized: AWS-recommended successor to lowestPrice for spot.
+      spot_allocation_strategy = "price-capacity-optimized"
+    }
+
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.ci_jenkins_io_ec2_agents[each.key].id
+        version            = aws_launch_template.ci_jenkins_io_ec2_agents[each.key].latest_version
+      }
+
+      dynamic "override" {
+        for_each = each.value.instance_types
+        content {
+          instance_type = override.value
+        }
+      }
+    }
+  }
+
+  dynamic "tag" {
+    for_each = merge(local.common_tags, {
+      "Name" = "ci-jenkins-io-ec2-agents-spot-${each.key}"
+    })
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  lifecycle {
+    # Prevent Terraform from resetting desired_capacity on every plan after Jenkins has scaled the ASG up/down.
+    ignore_changes = [desired_capacity]
+  }
+}
 # Allow agents to read Maven cache from S3
 resource "aws_iam_role" "ci_jenkins_io_ec2_agents" {
   name               = "ci-jenkins-io-ec2-agents"

--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -1,7 +1,6 @@
 ####################################################################################
-# ci.jenkins.io resources
+# ci.jenkins.io controller resources
 ####################################################################################
-
 ### Network resources
 resource "aws_eip" "ci_jenkins_io" {
   domain = "vpc"
@@ -87,53 +86,6 @@ data "aws_iam_policy_document" "jenkins_ec2_agents" {
   }
 }
 
-# Allow agents to read Maven cache from S3
-resource "aws_iam_role" "ci_jenkins_io_ec2_agents" {
-  name               = "ci-jenkins-io-ec2-agents"
-  assume_role_policy = data.aws_iam_policy_document.assume_role_ec2.json
-}
-
-resource "aws_iam_instance_profile" "ci_jenkins_io_ec2_agents" {
-  name = "ci-jenkins-io-ec2-agents"
-  role = aws_iam_role.ci_jenkins_io_ec2_agents.name
-}
-
-resource "aws_iam_policy" "s3_ci_jenkins_io_maven_cache_readonly_ec2" {
-  name        = "s3-ci-jenkins-io-maven-cache-readonly-ec2"
-  description = "IAM policy for S3 access (read-only) to ci_jenkins_io_maven_cache S3 bucket"
-
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Sid    = "MountpointFullBucketAccess",
-        Effect = "Allow",
-        Action = [
-          "s3:ListBucket"
-        ],
-        Resource = [
-          aws_s3_bucket.ci_jenkins_io_maven_cache.arn,
-        ],
-      },
-      {
-        Sid    = "MountpointFullObjectAccess",
-        Effect = "Allow",
-        Action = [
-          "s3:GetObject",
-        ],
-        Resource = [
-          "${aws_s3_bucket.ci_jenkins_io_maven_cache.arn}/*",
-        ],
-      },
-    ],
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "ec2_agents_s3_readonly" {
-  role       = aws_iam_role.ci_jenkins_io_ec2_agents.name
-  policy_arn = aws_iam_policy.s3_ci_jenkins_io_maven_cache_readonly_ec2.arn
-}
-
 ### Compute Resources
 resource "aws_key_pair" "ci_jenkins_io" {
   key_name = "ci-jenkins-io"
@@ -197,13 +149,6 @@ resource "aws_instance" "ci_jenkins_io" {
   }
 }
 
-## SSH Key used to access EC2 Agents (private key stored encrypted in SOPS)
-resource "aws_key_pair" "deployer" {
-  key_name   = "deployer-key"
-  public_key = trimspace(element(split("#", compact(split("\n", file("./ec2_agents_authorized_keys")))[0]), 0))
-  tags       = local.common_tags
-}
-
 ### DNS Zone delegated from Azure DNS (jenkins-infra/azure-net)
 # `updatecli` maintains sync between the 2 repositories using the infra reports (see outputs.tf)
 resource "aws_route53_zone" "aws_ci_jenkins_io" {
@@ -244,8 +189,10 @@ resource "aws_route53_record" "aaaa_assets_aws_ci_jenkins_io" {
   records = aws_instance.ci_jenkins_io.ipv6_addresses
 }
 
-##########################################################################################################################################################
+
+####################################################################################
 ## Section: S3 Bucket used for storing Artifact and stashes
+####################################################################################
 ## This bucket does not need logging, versioning nor encryption as all objects are public
 resource "aws_s3_bucket" "ci_jenkins_io_artifacts" {
   bucket = "aws-ci-jenkins-io-artifacts"
@@ -328,5 +275,60 @@ data "aws_iam_policy_document" "ci_jenkins_io_artifacts_objects" {
     ]
   }
 }
-# End of S3 Bucket Section
-##########################################################################################################################################################
+
+####################################################################################
+# ci.jenkins.io EC2 agents resources
+####################################################################################
+# Allow agents to read Maven cache from S3
+resource "aws_iam_role" "ci_jenkins_io_ec2_agents" {
+  name               = "ci-jenkins-io-ec2-agents"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_ec2.json
+}
+
+resource "aws_iam_instance_profile" "ci_jenkins_io_ec2_agents" {
+  name = "ci-jenkins-io-ec2-agents"
+  role = aws_iam_role.ci_jenkins_io_ec2_agents.name
+}
+
+resource "aws_iam_policy" "s3_ci_jenkins_io_maven_cache_readonly_ec2" {
+  name        = "s3-ci-jenkins-io-maven-cache-readonly-ec2"
+  description = "IAM policy for S3 access (read-only) to ci_jenkins_io_maven_cache S3 bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid    = "MountpointFullBucketAccess",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket"
+        ],
+        Resource = [
+          aws_s3_bucket.ci_jenkins_io_maven_cache.arn,
+        ],
+      },
+      {
+        Sid    = "MountpointFullObjectAccess",
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+        ],
+        Resource = [
+          "${aws_s3_bucket.ci_jenkins_io_maven_cache.arn}/*",
+        ],
+      },
+    ],
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ec2_agents_s3_readonly" {
+  role       = aws_iam_role.ci_jenkins_io_ec2_agents.name
+  policy_arn = aws_iam_policy.s3_ci_jenkins_io_maven_cache_readonly_ec2.arn
+}
+
+## SSH Key used to access EC2 Agents (private key stored encrypted in SOPS)
+resource "aws_key_pair" "deployer" {
+  key_name   = "deployer-key"
+  public_key = trimspace(element(split("#", compact(split("\n", file("./ec2_agents_authorized_keys")))[0]), 0))
+  tags       = local.common_tags
+}

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -1,0 +1,34 @@
+---
+# This file holds data tracked and updated automatically by updatecli but consumed by Terraform
+# as updatecli's HCL parser does not work well with nested maps
+ci.jenkins.io:
+  # TODO: track with updatecli
+  acp_url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/ # Mandatory trailing slash!
+  ec2_agents:
+    windows_2025:
+      # TODO: track with updatecli
+      ami_id: ami-0cd45fdc4f955c705
+      architecture: amd64
+      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      jdks: ["8", "11", "17", "21", "25"]
+      max_size: 50
+      os_version: 2025
+      os: windows
+    windows_2022:
+      # TODO: track with updatecli
+      ami_id: ami-0095110fb19a279e6
+      architecture: amd64
+      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      jdks: ["25"]
+      max_size: 20
+      os_version: 2022
+      os: windows
+    windows_2019:
+      # TODO: track with updatecli
+      ami_id: ami-0c06334d680ef93dc
+      architecture: amd64
+      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      jdks: ["25"]
+      max_size: 20
+      os_version: 2019
+      os: windows

--- a/locals.tf
+++ b/locals.tf
@@ -227,4 +227,35 @@ locals {
       cidr = cidrsubnet(cidrsubnets(local.vpc_cidr, 1, 1)[1], 3, 4)
     },
   ]
+
+  agent_definitions = {
+    # Flatten into one entry per (os_version, jdk) pair
+    for pair in flatten([
+      for agent_key, agent_value in yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["ec2_agents"] : [
+        for jdk in agent_value.jdks : {
+          key = "${agent_key}-jdk${jdk}"
+
+          ami_id         = agent_value.ami_id
+          architecture   = agent_value.architecture
+          instance_types = agent_value.instance_types
+          jdk            = jdk
+          max_size       = agent_value.max_size
+          os             = agent_value.os
+          os_version     = agent_value.os_version
+        }
+      ]
+    ]) : pair.key => pair
+  }
+
+  # Pre-render userData for each agent definition.
+  user_data = {
+    for name, agent in local.agent_definitions :
+    name => base64encode(templatefile("${path.module}/templates/ci.jenkins.io/ec2-${agent.os}-userdata.tpl", {
+      datadog_api_key = var.ci_jenkins_io_datadog_api_key
+      description     = name
+      ci_fqdn         = "ci.jenkins.io"
+      java_home       = agent.os == "windows" ? "C:/tools/jdk-${agent.jdk}" : "/opt/jdk-${agent.jdk}",
+      acp_url         = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["acp_url"],
+    }))
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,22 +63,22 @@ resource "local_file" "jenkins_infra_data_report" {
               # Only one subnet in the same AZ as the only ACP replica (e.g. where the 'applications' node pool is located)
               "subnet_id" = element([
                 for idx, subnet in local.vpc_private_subnets : module.vpc.private_subnets[idx] if subnet.name == "eks-1"
-              ],0),
+              ], 0),
               # Only one subnet in the same AZ as the only ACP replica (e.g. where the 'applications' node pool is located)
               "private_ip" = element([
                 for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.cidr_block... if subnet_data.tags.Name == "eks-1" } : cidrhost(element(data, 0), "-8")
-              ],0),
+              ], 0),
               "storage_class" = kubernetes_storage_class.cijenkinsio_agents_2_ebs_csi_premium_retain[local.agents_availability_zone].metadata[0].name,
             },
             "hub-mirror" = {
               # Only one subnet in the same AZ as the only ACP replica (e.g. where the 'applications' node pool is located)
               "subnet_id" = element([
                 for idx, subnet in local.vpc_private_subnets : module.vpc.private_subnets[idx] if subnet.name == "eks-1"
-              ],0),
+              ], 0),
               # Only one subnet in the same AZ as the only ACP replica (e.g. where the 'applications' node pool is located)
               "private_ip" = element([
                 for idx, data in { for subnet_index, subnet_data in module.vpc.private_subnet_objects : subnet_data.availability_zone => subnet_data.cidr_block... if subnet_data.tags.Name == "eks-1" } : cidrhost(element(data, 0), "-9")
-              ],0),
+              ], 0),
               "storage_class" = kubernetes_storage_class.cijenkinsio_agents_2_ebs_csi_premium_retain[local.agents_availability_zone].metadata[0].name,
             },
             "maven-cacher" = {

--- a/templates/ci.jenkins.io/ec2-windows-userdata.tpl
+++ b/templates/ci.jenkins.io/ec2-windows-userdata.tpl
@@ -1,0 +1,162 @@
+version: 1.1
+tasks:
+- task: executeScript
+  inputs:
+  - frequency: always
+    type: powershell
+    runAs: localSystem
+    content: |-
+      ## Set up permissions context (as you are Administrator here)
+      Set-ExecutionPolicy Unrestricted -Scope LocalMachine -Force -ErrorAction Ignore
+      # Don't set this before Set-ExecutionPolicy as it throws an error
+      $ErrorActionPreference = "stop"
+
+      ## Custom functions to manipulate environment variables
+      function AddToPathEnv {
+        param (
+          $path
+        )
+        Write-Host "Adding $path to the PATH environment variable..."
+        $oldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH).path
+        $newPath = '{0};{1}' -f $path,$oldPath
+        Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath | Out-Null
+        # Update self (script) environment
+        $env:Path = $newPath
+      }
+
+      function AddEnvToSystem {
+        param (
+          $name,
+          $value
+        )
+
+        Write-Host "Adding $name environment variable to system with the value $value..."
+        New-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name $name -Value $value | Out-Null
+        # Update self (script) environment
+        Set-Item "env:$name" $value
+      }
+
+      ## Set up custom environment (usually defined on agent templates with EC2/Azure VMs/Kubernetes Jenkins plugins)
+      ## Note: must be performed before jenkins user opens its SSH session so it's picked up by agent.jar process
+      AddEnvToSystem -name 'JAVA_HOME' -value '${java_home}'
+      AddToPathEnv -path '${java_home}/bin'
+      AddEnvToSystem -name 'ARTIFACT_CACHING_PROXY_SERVERID' -value '${acp_url}'
+      Get-Date
+
+      ## Setup datadog
+      (Get-Content C:\ProgramData\Datadog\datadog.yaml -Raw) -Replace 'api_key:', 'api_key: ${datadog_api_key}' | Set-Content C:\ProgramData\Datadog\datadog.yaml
+      Add-Content -Path C:\ProgramData\Datadog\datadog.yaml -Value "tags: [`"jenkins_controller:${ci_fqdn}`", `"jenkins_agent_type:ephemeral_ec2`", `"jenkins_agent_description:${description}`"]"
+      & "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" restart-service
+      Write-Output 'Datadog service setup'
+      Get-Date
+
+      ## Disable WinRM
+      Remove-Item -Path WSMan:\Localhost\listener\listener* -Recurse
+      cmd.exe /c net stop winrm
+      Write-Output 'WinRM disabled'
+      Get-Date
+
+      ## Setup NVMe(s) and map it to the Z: drive
+      $nb = Get-Disk | Where-Object PartitionStyle -eq 'RAW' | tee -Variable Disks | measure
+      Write-Output "$nb.Count disk found."
+      Get-Date
+      Switch ($nb.Count)
+      {
+        0 {Write-Output "No RAW disk found."}
+        1 {
+            $Disks | Initialize-Disk -PartitionStyle MBR
+            $Disks | New-Partition -UseMaximumSize -MbrType IFS
+            $Partition = Get-Partition -DiskNumber $Disks.Number
+            $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
+            $Partition | Add-PartitionAccessPath -AccessPath "Z:"
+            Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
+        }
+        default {
+            $Disks | ForEach-Object -Begin {Get-Date} -Process {
+                    Initialize-Disk -PartitionStyle MBR -PassThru -DiskNumber $_.Number
+                    New-Partition -UseMaximumSize -MbrType IFS
+                    $Partition = Get-Partition -DiskNumber $_.Number
+                    $Partition | Format-Volume -FileSystem NTFS -Confirm:$false
+                    $Partition | Add-PartitionAccessPath -AccessPath "Z:"
+                } -End {Get-Date}
+            Get-WmiObject Win32_Volume | Format-Table Name, Label, FreeSpace, Capacity
+        }
+      }
+      Write-Output 'Disk setup finished.'
+      Get-Date
+
+      ## Setup Docker Engine (allowing both admin and non-admin users)
+      $dockerGroup = 'docker-users'
+      try {Get-LocalGroup -Name $dockerGroup;} catch {New-LocalGroup -Name $dockerGroup;}
+
+      # Note: file path MUST use Unix-style separator (/)
+      @"
+      {
+        "hosts": ["npipe://"],
+        "data-root": "Z:/docker",
+        "group": "$dockerGroup"
+      }
+      "@ | Set-Content C:\ProgramData\Docker\config\daemon.json
+      # Restart docker engine
+      Restart-Service docker
+      docker info
+      Write-Output 'Docker Engine setup finished.'
+      Get-Date
+
+      # Enable Developer mode to allow creating symlinks for non-admin users
+      reg add "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" /v "AllowDevelopmentWithoutDevLicense" /t REG_DWORD /d 1 /f
+
+      # Set up Windows default Users profiles location to the custom data disk drive
+      $userpath = 'Z:\Users'
+      $regpath = 'HKLM:\Software\Microsoft\Windows NT\CurrentVersion\ProfileList'
+      $regname = 'ProfilesDirectory'
+      Set-ItemProperty -path $regpath -name $regname -value $userpath
+      Write-Output "Set up default user profiles to $userpath"
+
+      # Create the 'jenkins' agent's user account
+      $username = 'jenkins'
+      ## TODO: generate random password
+      $userPassword = 'J3nkinsSuperSecret1234!'
+      $pw = ConvertTo-SecureString -String $userPassword -AsPlainText -Force
+      New-LocalUser -Name $username -Password $pw
+
+      $sshGroup = "openssh users"
+      try {Get-LocalGroup -Name $sshGroup;} catch {New-LocalGroup -Name $sshGroup;}
+
+      Add-LocalGroupMember -Group $sshGroup -Member $username
+      Add-LocalGroupMember -Group $dockerGroup -Member $username
+
+      Write-Output "User $username created."
+      Get-Date
+
+      ## Ensure User Profile and CryptoAPI seed generator are initialized
+      ## User Profile: ensures the userhome and userprofile are all in the same drive (C: or Z: based on setup)
+      ## CryptoAPI seed generator: requires a password SSH/WinRM/powershell non-interactive session
+      ## See https://github.com/PowerShell/Win32-OpenSSH/discussions/2420 and https://github.com/jenkinsci/credentials-plugin/pull/999
+      $env:DISPLAY = '0'
+      $env:SSH_ASKPASS_REQUIRE = 'force'
+      $env:SSH_ASKPASS = 'C:\askpass.bat'
+      @"
+      @echo off
+      echo $userPassword
+      "@ | Set-Content $env:SSH_ASKPASS
+      echo 'java.security.SecureRandom.getInstanceStrong().generateSeed(1)' | ssh $username@localhost -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null "${java_home}\bin\jshell.exe"
+      Remove-Item -Path "$env:SSH_ASKPASS" -Force
+      Write-Output 'Initialized User Profile and CryptoAPI through SSH with password authentication'
+      Get-Date
+
+      # Setup SSH key for user in its profile (as it is non admin) reusing the same key
+      # Must be done only AFTER setting up the "CryptoAPI" seed generator to ensure agent does not connect too early (e.g. before user profile or seed generator initialization)
+      $userSSHDir = "$userpath\$username\.ssh"
+      New-Item -ItemType Directory -Path "$userSSHDir" -Force | Out-Null
+      Copy-Item -Path "C:\ProgramData\ssh\administrators_authorized_keys" -Destination "$userSSHDir\authorized_keys"
+      Get-Date
+
+      ## Retrieve Maven cache from S3 bucket
+      New-Item -ItemType Directory -Path C:/cache
+      aws s3 cp s3://ci-jenkins-io-maven-cache/maven-bom-local-repo.tar.gz C:/cache/
+      Get-Date
+
+      ## Mark cloud init as finished using a marker file
+      New-Item -Path "Z:/Temp" -ItemType "Directory"
+      New-Item -Path "Z:/Temp/.cloud-init.done" -ItemType "File" -Value "Cloud Init"

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,9 @@ variable "environment" {
   type    = string
   default = "staging"
 }
+
+variable "ci_jenkins_io_datadog_api_key" {
+  description = "Datadog API key (sensitive) used by ci.jenkins.io to report metrics."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5202

Requires https://github.com/jenkins-infra/kubernetes-management/pull/7894 to have the credential `ci-jenkins-io-ephemeral-agents-datadog-api-key` set up.

Review should only happen on https://github.com/jenkins-infra/terraform-aws-sponsorship/pull/543/changes/d1a1134f7a48ec76f3025d6e24bd5528c9ed5492 (as the other commit is formatting only).


This PR introduces 15 new resources related to the ci.jenkins.io ephemeral agents:

- A new IAM policy is attached to the ci.jenkins.io controller's IAM role to allow fleet/ASG management with the [EC2 Fleet plugin](https://plugins.jenkins.io/ec2-fleet/)
- 7 ASGs and their 7 associated templates to handle the Windows EC2 spot workloads for ci.jenkins.io:
  - 3 Windows versions: 2019 and 2022 only feature JDK25 as they should only be used by Docker Windows builds, but Windows 2025 is declined with each of the 5 JDKs to provide all the `maven-XX-windows` labels
  - Imported and adapted the user-data script from puppet rendering into a Terraform template. Removed all conditionals around "local NVMe or not local NVMe", "remote user is jenkins or Administrator", etc. as it made no sense at all in this context.
- We have to track the AMI IDs, ACP URL in a subsequent PR with updatecli since these elements are now managed on the Launch templates. As such I've set up the source data from a YAML file to ease our life (since updatecli does not support nested HCL structures :'( )
- The datadog API key passed to agent's datadog-agent is added as a Jenkins credential in this pipeline (duplicating the secrets value between SOPS -> kubernets management for here and in the Puppet eYaml).

----


Notes:

- No Ubuntu case yet. Will need a few changes (including the user-data script).
- Handling the user-data scripts changes will be tedious as we'll need it in 3 source code locations: Puppet, Kubernetes-Management (Linux only today) and here. I wonder if we shouldn't put it in packer-images once for all. 
  - It would require to make it "universal" (e.g. handle all cases) but it would avoid tedious cherry pick each time we change it.
  - Using an automated cherry-pick technique with updatecli is not easily achieved since the templating engines are all different: Terraform TPL, Helm template and Puppet ERB. 
  - Using Claude Code here made my life miserable: spent more time fixing the forgotten or hallucinated script lines. It helped on converting between Puppet ERB to Terraform TPL though.
 