### PR TITLE
feat(ci.jenkins.io/ec2) add JDK21 for Windows 2019 and 2022

### DIFF
--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -30,13 +30,13 @@ ci.jenkins.io:
       os: windows
     windows_2022:
       instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
-      jdks: ["25"]
+      jdks: ["21", "25"]
       max_size: 20
       os_version: 2022
       os: windows
     windows_2019:
       instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
-      jdks: ["25"]
+      jdks: ["21", "25"]
       max_size: 20
       os_version: 2019
       os: windows

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -24,7 +24,7 @@ ci.jenkins.io:
       os: windows
     windows_2025-infratest:
       instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
-      jdks: ["25"]
+      jdks: ["21", "25"]
       max_size: 10
       os_version: 2025
       os: windows


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4858381370

- The expected JDK (outside the `maven-XX-windows` agents) is 21. Not 25 (ref. https://github.com/jenkins-infra/acceptance-tests/blob/240c14b40248e82e2de34e53a7482e3cdf35d939/checks.ps1#L17).
- Removing the JDK25 would break things in ci.jenkins.io. Let's add JDK21 here, then switch ci.jio to them and finally remove all JDK25.