### PR TITLE
feat(ci.jenkins.io/ec2_agents) add a new 'ondemand' ASG for `windows-infratest`

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -359,7 +359,7 @@ data "aws_iam_policy_document" "ci_jenkins_io_artifacts_objects" {
 # ci.jenkins.io EC2 agents resources
 ####################################################################################
 resource "aws_launch_template" "ci_jenkins_io_ec2_agents" {
-  for_each = local.agent_definitions
+  for_each = local.ci_jenkins_io_launch_template_definitions
 
   name = "ci-jenkins-io-${each.key}"
   # No instance_type here: overridden by the ASG mixed_instances_policy
@@ -398,7 +398,13 @@ resource "aws_launch_template" "ci_jenkins_io_ec2_agents" {
     http_put_response_hop_limit = 1
   }
 
-  user_data = local.user_data[each.key]
+  user_data = base64encode(templatefile("${path.module}/templates/ci.jenkins.io/ec2-${each.value.os}-userdata.tpl", {
+    datadog_api_key = var.ci_jenkins_io_datadog_api_key
+    description     = each.key
+    ci_fqdn         = "ci.jenkins.io"
+    java_home       = each.value.os == "windows" ? "C:/tools/jdk-${each.value.jdk}" : "/opt/jdk-${each.value.jdk}",
+    acp_url         = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["acp_url"],
+  }))
 
   tag_specifications {
     resource_type = "instance"
@@ -425,9 +431,9 @@ resource "aws_launch_template" "ci_jenkins_io_ec2_agents" {
   }
 }
 resource "aws_autoscaling_group" "ci_jenkins_io_ec2_agents" {
-  for_each = local.agent_definitions
+  for_each = local.ci_jenkins_io_asg_definitions
 
-  name = "ci-jenkins-io-spot-${each.key}"
+  name = "ci-jenkins-io-${each.key}"
 
   ## The EC2 Fleet plugin manages desired_capacity; we set it to 0 here so no
   ## instances are launched before Jenkins is wired up.
@@ -435,6 +441,10 @@ resource "aws_autoscaling_group" "ci_jenkins_io_ec2_agents" {
   min_size         = 0
   max_size         = each.value.max_size
   desired_capacity = 0
+
+  # The EC2 Fleet plugin enables the Scale-In protection if disabled
+  # Ref. https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/docs/FAQ.md?plain=1#L66
+  protect_from_scale_in = true
 
   vpc_zone_identifier = [
     for idx, subnet in local.vpc_private_subnets :
@@ -453,21 +463,21 @@ resource "aws_autoscaling_group" "ci_jenkins_io_ec2_agents" {
 
   mixed_instances_policy {
     instances_distribution {
-      # All capacity from spot
-      on_demand_base_capacity                  = 0
-      on_demand_percentage_above_base_capacity = 0
+      on_demand_base_capacity                  = each.value.pricing_type == "spot" ? 0 : 100
+      on_demand_percentage_above_base_capacity = each.value.pricing_type == "spot" ? 0 : 100
       # price-capacity-optimized: AWS-recommended successor to lowestPrice for spot.
-      spot_allocation_strategy = "price-capacity-optimized"
+      spot_allocation_strategy      = each.value.pricing_type == "spot" ? "price-capacity-optimized" : ""
+      on_demand_allocation_strategy = each.value.pricing_type == "spot" ? "" : "lowest-price"
     }
 
     launch_template {
       launch_template_specification {
-        launch_template_id = aws_launch_template.ci_jenkins_io_ec2_agents[each.key].id
-        version            = aws_launch_template.ci_jenkins_io_ec2_agents[each.key].latest_version
+        launch_template_id = aws_launch_template.ci_jenkins_io_ec2_agents[each.value.launch_template_name].id
+        version            = aws_launch_template.ci_jenkins_io_ec2_agents[each.value.launch_template_name].latest_version
       }
 
       dynamic "override" {
-        for_each = each.value.instance_types
+        for_each = each.value.instance_types[each.value.pricing_type]
         content {
           instance_type = override.value
         }
@@ -477,7 +487,7 @@ resource "aws_autoscaling_group" "ci_jenkins_io_ec2_agents" {
 
   dynamic "tag" {
     for_each = merge(local.common_tags, {
-      "Name" = "ci-jenkins-io-ec2-agents-spot-${each.key}"
+      "Name" = "ci-jenkins-io-ec2-agents-${each.key}"
     })
     content {
       key                 = tag.key

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -17,26 +17,35 @@ ci.jenkins.io:
   acp_url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/ # Mandatory trailing slash!
   ec2_agents:
     windows_2025:
-      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
       jdks: ["8", "11", "17", "21", "25"]
       max_size: 50
       os_version: 2025
       os: windows
+      pricing_types: ["spot"]
     windows_2025-infratest:
-      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+        ondemand: ["m5ad.xlarge", "r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
       jdks: ["21"]
       max_size: 10
       os_version: 2025
       os: windows
+      pricing_types: ["spot", "ondemand"]
     windows_2022:
-      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
       jdks: ["21"]
       max_size: 20
       os_version: 2022
       os: windows
+      pricing_types: ["spot"]
     windows_2019:
-      instance_types: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
       jdks: ["21"]
       max_size: 20
       os_version: 2019
       os: windows
+      pricing_types: ["spot"]

--- a/locals.tf
+++ b/locals.tf
@@ -230,7 +230,8 @@ locals {
 
   ami_ids = yamldecode(file("${path.module}/locals-data.yaml"))["ami_ids"]
 
-  agent_definitions = {
+  # Launch template definitions are the same for different ASGs (usually spot/ondemand)
+  ci_jenkins_io_launch_template_definitions = {
     # Flatten into one entry per (os_version, jdk) pair
     for pair in flatten([
       for agent_key, agent_value in yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["ec2_agents"] : [
@@ -244,20 +245,30 @@ locals {
           max_size       = agent_value.max_size
           os             = agent_value.os
           os_version     = agent_value.os_version
+          pricing_types  = agent_value.pricing_types
         }
       ]
     ]) : pair.key => pair
   }
 
-  # Pre-render userData for each agent definition.
-  user_data = {
-    for name, agent in local.agent_definitions :
-    name => base64encode(templatefile("${path.module}/templates/ci.jenkins.io/ec2-${agent.os}-userdata.tpl", {
-      datadog_api_key = var.ci_jenkins_io_datadog_api_key
-      description     = name
-      ci_fqdn         = "ci.jenkins.io"
-      java_home       = agent.os == "windows" ? "C:/tools/jdk-${agent.jdk}" : "/opt/jdk-${agent.jdk}",
-      acp_url         = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["acp_url"],
-    }))
+  ci_jenkins_io_asg_definitions = {
+    # Flatten into one entry per (agent_name, pricing_type) pair
+    for pair in flatten([
+      for agent_key, agent_value in local.ci_jenkins_io_launch_template_definitions : [
+        for pt in agent_value.pricing_types : {
+          key = "${pt}-${agent_key}"
+
+          launch_template_name = "${agent_key}"
+          ami_id               = local.ami_ids[agent_value.os][agent_value.os_version][lookup(agent_value, "architecture", "amd64")]
+          architecture         = lookup(agent_value, "architecture", "amd64")
+          instance_types       = agent_value.instance_types
+          jdk                  = agent_value.jdk
+          max_size             = agent_value.max_size
+          os                   = agent_value.os
+          os_version           = agent_value.os_version
+          pricing_type         = pt
+        } if contains(["spot", "ondemand"], pt)
+      ]
+    ]) : pair.key => pair
   }
 }

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,32 @@
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-jdk8"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-jdk8"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-jdk11"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-jdk11"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-jdk17"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-jdk17"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-jdk21"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-jdk21"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-jdk25"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-jdk25"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2025-infratest-jdk21"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2025-infratest-jdk21"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2022-jdk21"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2022-jdk21"]
+}
+moved {
+  from = aws_autoscaling_group.ci_jenkins_io_ec2_agents["windows_2019-jdk21"]
+  to   = aws_autoscaling_group.ci_jenkins_io_ec2_agents["spot-windows_2019-jdk21"]
+}


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5202#issuecomment-4867776831

This PR adds support of on-demand ASG for ci.jenkins.io EC2 fleets with a single example on the `windows-infratest`.
It introduces the following changes:

- On-Demand has a distinct list of instance types in the YAML specification file has we might use different instance sizes
  - Note: the on-demand allocation strategy is the "lowest price".
- A couple of "spot" and "ondemand" ASGs share the same launch template. Reworked the locals to fulfill this constraint to avoid repeating too much data in the local(yaml/hcl)
- Moved resources internally to support the spot/ondemand naming
- chore: moved the user_data template generation inside the launch template
- fix: ensure that scale-in protection is enabled (enabled no matter what by the EC2 Fleet plugin)