### PR TITLE
cleanup(ci/jenkins.io/ec2 agents) remove OnDemand windows-infratest and bump AMIs to 2.117.0

### DIFF
--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -5,13 +5,13 @@ ami_ids:
   windows:
     2025:
       # TODO: track with updatecli
-      amd64: ami-0cd45fdc4f955c705
+      amd64: ami-0bb30b862e5ced83e # 2.117.0
     2022:
       # TODO: track with updatecli
-      amd64: ami-0095110fb19a279e6
+      amd64: ami-007b9880393ecdafb # 2.117.0
     2019:
       # TODO: track with updatecli
-      amd64: ami-0c06334d680ef93dc
+      amd64: ami-071cec3b00cd585d9 # 2.117.0
 ci.jenkins.io:
   # TODO: track with updatecli
   acp_url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/ # Mandatory trailing slash!

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -33,7 +33,7 @@ ci.jenkins.io:
       max_size: 10
       os_version: 2025
       os: windows
-      pricing_types: ["spot", "ondemand"]
+      pricing_types: ["spot"]
     windows_2022:
       instance_types:
         spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]


### PR DESCRIPTION
Cleaning up the Windows EC2 Fleet ASG for ci.jenkins.io agents (after https://github.com/jenkins-infra/helpdesk/issues/5185, as part of https://github.com/jenkins-infra/helpdesk/issues/5202).

This PR introduces the 2 following changes:

- cleanup: remove the `ondemand` ASG for the `window-infratest` agent template (only need spot)
- feat: bump the AMI IDs for the 3 windows server lines to our 2.117.0 (manual cherry-pick of https://github.com/jenkins-infra/jenkins-infra/pull/4947)