### PR TITLE
feat(ci.jenkins.io/ec2-agents) add a new ASG for `ubuntu-infratest` agent template with our Ubuntu 22.04 amd64 image

### DIFF
--- a/ci.jenkins.io.tf
+++ b/ci.jenkins.io.tf
@@ -399,11 +399,12 @@ resource "aws_launch_template" "ci_jenkins_io_ec2_agents" {
   }
 
   user_data = base64encode(templatefile("${path.module}/templates/ci.jenkins.io/ec2-${each.value.os}-userdata.tpl", {
-    datadog_api_key = var.ci_jenkins_io_datadog_api_key
-    description     = each.key
-    ci_fqdn         = "ci.jenkins.io"
-    java_home       = each.value.os == "windows" ? "C:/tools/jdk-${each.value.jdk}" : "/opt/jdk-${each.value.jdk}",
-    acp_url         = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["acp_url"],
+    datadog_api_key           = var.ci_jenkins_io_datadog_api_key
+    description               = each.key
+    ci_fqdn                   = "ci.jenkins.io"
+    java_home                 = each.value.os == "windows" ? "C:/tools/jdk-${each.value.jdk}" : "/opt/jdk-${each.value.jdk}",
+    acp_url                   = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["acp_url"],
+    dockerhub_mirror_hostname = yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["dockerhub_mirror_hostname"],
   }))
 
   tag_specifications {

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -2,6 +2,12 @@
 # This file holds data tracked and updated automatically by updatecli but consumed by Terraform
 # as updatecli's HCL parser does not work well with nested maps
 ami_ids:
+  ubuntu:
+    22.04:
+      # TODO: track with updatecli
+      amd64: ami-06dd87e8e5fa65518 # 2.117.0
+      # TODO: track with updatecli
+      arm64: ami-0acfe18e1dc957ac3 # 2.117.0
   windows:
     2025:
       # TODO: track with updatecli
@@ -15,7 +21,16 @@ ami_ids:
 ci.jenkins.io:
   # TODO: track with updatecli
   acp_url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/ # Mandatory trailing slash!
+  dockerhub_mirror_hostname: k8s-hubmirro-hubmirro-477f7dfd76-9bbe4e560ee83036.elb.us-east-2.amazonaws.com
   ec2_agents:
+    ubuntu_22.04-infratest:
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      jdks: ["21"]
+      max_size: 5
+      os_version: 22.04
+      os: ubuntu
+      pricing_types: ["spot"]
     windows_2025:
       instance_types:
         spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]

--- a/templates/ci.jenkins.io/ec2-ubuntu-userdata.tpl
+++ b/templates/ci.jenkins.io/ec2-ubuntu-userdata.tpl
@@ -1,0 +1,139 @@
+#!/bin/sh
+set -eux
+
+# Ensure Jenkins controller does not start the agent in process in its workspace until we are ready
+systemctl stop sshd.service
+
+## Setup Datadog service
+(
+    systemctl stop datadog-agent.service
+    mkdir -p /var/log/datadog /etc/datadog-agent
+    sed 's/api_key:.*/api_key: ${datadog_api_key}/' /etc/datadog-agent/datadog.yaml.example > /etc/datadog-agent/datadog.yaml
+    sed -i 's/# site:.*/site: datadoghq.com/' /etc/datadog-agent/datadog.yaml
+    echo "tags: [\"jenkins_controller:ci.jenkins.io\", \"jenkins_agent_type:ec2_asg\"]" >> /etc/datadog-agent/datadog.yaml
+    chown dd-agent:dd-agent /etc/datadog-agent/datadog.yaml
+    chmod 640 /etc/datadog-agent/datadog.yaml
+    chown dd-agent:dd-agent /var/log/datadog
+    chmod 770 /var/log/datadog
+    systemctl daemon-reload
+    systemctl enable datadog-agent.service
+    systemctl start datadog-agent.service
+) 2>&1 | tee /var/log/agent-init-datadog.log
+
+## Setup local NVMe
+MNT_DIR="/home/jenkins/agent"
+
+disks=""
+tmpfile=$(mktemp)
+find -L /dev/disk/by-id/ -xtype l -name '*NVMe_Instance_Storage_*' > "$${tmpfile}"
+while IFS= read -r disk; do
+    disks="$${disks} $${disk}"
+done < "$${tmpfile}"
+rm -f "$${tmpfile}"
+
+## Bail early if there are no ephemeral disks to setup
+if [ -z "$${disks}" ]; then
+    echo "no NVMe instance storage disks found!"
+else
+    md_name="workspace"
+    md_device="/dev/md/$${md_name}"
+    md_config="/.aws/mdadm.conf"
+    array_mount_point="$${MNT_DIR}/"
+    mkdir -p "$(dirname "$${md_config}")"
+
+    ## Get devices of NVMe instance storage ephemeral disks
+    EPHEMERAL_DISKS=""
+    tmpfile=$(mktemp)
+    for disk in $${disks}; do
+        realpath "$${disk}"
+    done | sort -u > "$${tmpfile}"
+    while IFS= read -r disk; do
+        EPHEMERAL_DISKS="$${EPHEMERAL_DISKS:+^$EPHEMERAL_DISKS }$${disk}"
+    done < "$${tmpfile}"
+    rm -f "$${tmpfile}"
+
+    if [ ! -s "$${md_config}" ]; then
+        set -- "$${EPHEMERAL_DISKS}"
+        num_disks=$#
+
+        mdadm --create --force --verbose \
+            "$${md_device}" \
+            --level=0 \
+            --name="$${md_name}" \
+            --raid-devices="$${num_disks}" \
+            "$@"
+
+        mdadm --detail --scan > "$${md_config}"
+    fi
+
+    # Format the array if not already formatted.
+    if [ -z "$(lsblk "$${md_device}" -o fstype --noheadings)" ]; then
+        ## By default, mkfs tries to use the stripe unit of the array (512k),
+        ## for the log stripe unit, but the max log stripe unit is 256k.
+        ## So instead, we use 32k (8 blocks) to avoid a warning of breaching the max.
+        ## mkfs.xfs defaults to 32k after logging the warning since the default log buffer size is 32k.
+        ## Instances are delivered with disks fully trimmed, so TRIM is skipped at creation time.
+        mkfs.xfs -K -l su=8b "$${md_device}"
+    fi
+
+    ## Create the mount directory
+    mkdir -p "$${array_mount_point}"
+
+    dev_uuid=$(blkid -s UUID -o value "$${md_device}")
+    mount_unit_name="$(systemd-escape --path --suffix=mount "$${array_mount_point}")"
+    cat > "/etc/systemd/system/$${mount_unit_name}" <<EOF
+    [Unit]
+    Description=Mount EC2 Instance Store NVMe disk RAID0
+    [Mount]
+    What=UUID=$${dev_uuid}
+    Where=$${array_mount_point}
+    Type=xfs
+    Options=defaults,noatime
+    [Install]
+    WantedBy=multi-user.target
+EOF
+    systemd-analyze verify "$${mount_unit_name}"
+    systemctl enable "$${mount_unit_name}" --now
+    chown -R jenkins:jenkins "$${array_mount_point}"
+fi
+
+## Setup Docker Engine
+mkdir -p /etc/docker
+cat <<EOF >/etc/docker/daemon.json
+{
+    "insecure-registries": ["${dockerhub_mirror_hostname}:5000"],
+    "registry-mirrors": ["http://${dockerhub_mirror_hostname}:5000"]
+}
+EOF
+systemctl daemon-reload
+systemctl restart docker
+
+## Also provide Docker BuildX TOML configuration
+cat <<EOF >/etc/buildkitd.toml
+debug = true
+[registry."docker.io"]
+    mirrors = ["${dockerhub_mirror_hostname}:5000"]
+    http = true
+    insecure = true
+EOF
+
+## Setup default java (agent process may use another explicit one)
+update-alternatives --install /usr/bin/java java "${java_home}/bin/java" 2000
+
+## Set up custom environment (usually defined on agent templates with EC2/Azure VMs/Kubernetes Jenkins plugins)
+## Note: must be performed before jenkins user opens its SSH session so it's picked up by agent.jar process
+echo 'JAVA_HOME=${java_home}' >> /etc/environment
+echo 'PATH=${java_home}/bin/java:$PATH' >> /etc/environment
+echo 'ARTIFACT_CACHING_PROXY_SERVERID=${acp_url}' >> /etc/environment
+source /etc/environment # Sanity check
+
+systemctl start sshd.service
+
+## Retrieve Maven cache from S3 bucket
+mkdir -p /cache
+aws s3 cp s3://ci-jenkins-io-maven-cache/maven-bom-local-repo.tar.gz /cache/
+chown -R root:jenkins /cache
+
+## Mark cloud init as finished using a marker file
+mkdir -p "/tmp"
+touch "/tmp/.cloud-init.done"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5190#issuecomment-4876488201

This PR introduces the following changes:

- Add the Ubuntu 22.04 AMIs in the local YAML setup (2.117.0, in line with current Windows)
  - Note: still manually managed. No automatic update.
- Add support for Linux (Ubuntu) ASG with:
  - Userdata parameterized like windows user_data. A few notes:
    - Added the DockerHub mirror URL as new parameter (not used on Windows as it was buggy with Docker CE on Windows 2019/2022).
    - Script content is the same `sh` script as the rendered version from ci.jenkins.io (defined in https://github.com/jenkins-infra/jenkins-infra/blob/2c50f9cae0ed3d8a492829238d8b780bb28f4bbd/dist/profile/templates/jenkinscontroller/casc/clouds-ec2.yaml.erb#L268-L402). Except the conditions: we assume there is a local NVMe to be mounted in `/home/jenkins/agent` (same idea as for Windows), a S3 caching retrieval and the `.cloudinit.done` file in `/tmp`.
    - Added the `JAVA_HOME`, `PATH` and ACP URL setup in `/etc/environment`.
- Add a new ASG for `ubuntu_22.04-infratest` to use these changes

Note for the EC2 Fleet (Puppet + JCasC side) we'll have to:
- Add a prefix command to wait for cloud init to be finished and to source `/etc/environment` to load the new variables (same as the Windows Chocolatey's `refreshenv`)