### PR TITLE
feat(ci.jenkins.io/ec2_agents) add Ubuntu 22.04 Spot ASG and fix java's PATH in user_data

### DIFF
--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -23,6 +23,14 @@ ci.jenkins.io:
   acp_url: http://k8s-artifact-artifact-3d1949c260-a3739c22ffe2d924.elb.us-east-2.amazonaws.com:8080/ # Mandatory trailing slash!
   dockerhub_mirror_hostname: k8s-hubmirro-hubmirro-477f7dfd76-9bbe4e560ee83036.elb.us-east-2.amazonaws.com
   ec2_agents:
+    ubuntu_22.04:
+      instance_types:
+        spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]
+      jdks: ["21"]
+      max_size: 50
+      os_version: 22.04
+      os: ubuntu
+      pricing_types: ["spot"]
     ubuntu_22.04-infratest:
       instance_types:
         spot: ["r8id.xlarge", "m8id.xlarge", "r5ad.xlarge", "r5dn.xlarge"]

--- a/templates/ci.jenkins.io/ec2-ubuntu-userdata.tpl
+++ b/templates/ci.jenkins.io/ec2-ubuntu-userdata.tpl
@@ -123,7 +123,7 @@ env_source_file=/etc/profile.d/jenkins-agent
 mkdir -p "$(dirname "$${env_source_file}")"
 touch "$${env_source_file}"
 echo 'export JAVA_HOME=${java_home}' >> "$${env_source_file}"
-echo 'export PATH=${java_home}/bin/java:$PATH' >> "$${env_source_file}"
+echo 'export PATH=${java_home}/bin:$PATH' >> "$${env_source_file}"
 echo 'export ARTIFACT_CACHING_PROXY_SERVERID=${acp_url}' >> "$${env_source_file}"
 # Sanity checks
 cat "$${env_source_file}"


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/5190