### PR TITLE
chore(updatecli) track external IPs from public DNS records

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -172,8 +172,8 @@ locals {
 
   external_ips = {
     # Jenkins Puppet Master
-    "puppet.jenkins.io" = local.external_ip_puppet_jenkins_io,
-    "ldap.jenkins.io"   = local.external_ip_ldap_jenkins_io,
+    "puppet.jenkins.io"   = local.external_ip_puppet_jenkins_io,
+    "ldap.jenkins.io"     = local.external_ip_ldap_jenkins_io,
     "s390x.ci.jenkins.io" = local.external_ip_s390x_ci_jenkins_io,
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -167,13 +167,14 @@ locals {
   external_ip_puppet_jenkins_io = "20.12.27.65"
   # Tracked by 'updatecli' from public DNS record: ldap.jenkins.io
   external_ip_ldap_jenkins_io = "20.57.70.169"
+  # Tracked by 'updatecli' from jenkins-infra hieradata (s390x permanent agent ssh host)
+  external_ip_s390x_ci_jenkins_io = "148.100.84.76"
 
   external_ips = {
     # Jenkins Puppet Master
     "puppet.jenkins.io" = local.external_ip_puppet_jenkins_io,
     "ldap.jenkins.io"   = local.external_ip_ldap_jenkins_io,
-    # TODO: automate retrieval of this IP with updatecli
-    "s390x.ci.jenkins.io" = "148.100.84.76",
+    "s390x.ci.jenkins.io" = local.external_ip_s390x_ci_jenkins_io,
   }
 
   ssh_admin_ips = [

--- a/locals.tf
+++ b/locals.tf
@@ -162,15 +162,20 @@ locals {
     # Connections routed through the VPN
     "private.vpn.jenkins.io" = split(" ", local.outbound_ips_private_vpn_jenkins_io),
   }
+
+  # Tracked by 'updatecli' from public DNS record: puppet.jenkins.io
+  external_ip_puppet_jenkins_io = "20.12.27.65"
+  # Tracked by 'updatecli' from public DNS record: ldap.jenkins.io
+  external_ip_ldap_jenkins_io = "20.57.70.169"
+
   external_ips = {
     # Jenkins Puppet Master
-    # TODO: automate retrieval of this IP with updatecli
-    "puppet.jenkins.io" = "20.12.27.65",
-    # TODO: automate retrieval of this IP with updatecli
-    "ldap.jenkins.io" = "20.57.70.169",
+    "puppet.jenkins.io" = local.external_ip_puppet_jenkins_io,
+    "ldap.jenkins.io"   = local.external_ip_ldap_jenkins_io,
     # TODO: automate retrieval of this IP with updatecli
     "s390x.ci.jenkins.io" = "148.100.84.76",
   }
+
   ssh_admin_ips = [
     for ip in flatten(concat(
       # Allow Terraform management from infra.ci agents

--- a/updatecli/updatecli.d/external-ips.yaml
+++ b/updatecli/updatecli.d/external-ips.yaml
@@ -37,6 +37,16 @@ sources:
       environments:
         - name: PATH
 
+  getS390xAgentIP:
+    kind: yaml
+    name: Retrieve the s390x permanent agent IP from jenkins-infra hieradata
+    spec:
+      file: https://raw.githubusercontent.com/jenkins-infra/jenkins-infra/master/hieradata/clients/aws.ci.jenkins.io.yaml
+      key: "$.'profile::jenkinscontroller::jcasc'.permanent_agents.s390x-agent.ssh.host"
+    transformers:
+      - trimprefix: '"'
+      - trimsuffix: '"'
+
 targets:
   updatePuppetJenkinsIoIP:
     name: Update puppet.jenkins.io external IP in locals.tf
@@ -54,6 +64,15 @@ targets:
     spec:
       file: locals.tf
       path: locals.external_ip_ldap_jenkins_io
+    scmid: default
+
+  updateS390xAgentIP:
+    name: Update s390x.ci.jenkins.io external IP in locals.tf
+    kind: hcl
+    sourceid: getS390xAgentIP
+    spec:
+      file: locals.tf
+      path: locals.external_ip_s390x_ci_jenkins_io
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/external-ips.yaml
+++ b/updatecli/updatecli.d/external-ips.yaml
@@ -1,0 +1,67 @@
+name: Update external IPs from public DNS records
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  getPuppetJenkinsIoIP:
+    kind: shell
+    name: Retrieve the public IPv4 for puppet.jenkins.io
+    spec:
+      command: |
+        set -eu
+        ip=$(dig +short A puppet.jenkins.io | grep -E '^[0-9.]+$' | head -n1)
+        test -n "$ip"
+        echo "$ip"
+      environments:
+        - name: PATH
+
+  getLdapJenkinsIoIP:
+    kind: shell
+    name: Retrieve the public IPv4 for ldap.jenkins.io
+    spec:
+      command: |
+        set -eu
+        ip=$(dig +short A ldap.jenkins.io | grep -E '^[0-9.]+$' | head -n1)
+        test -n "$ip"
+        echo "$ip"
+      environments:
+        - name: PATH
+
+targets:
+  updatePuppetJenkinsIoIP:
+    name: Update puppet.jenkins.io external IP in locals.tf
+    kind: hcl
+    sourceid: getPuppetJenkinsIoIP
+    spec:
+      file: locals.tf
+      path: locals.external_ip_puppet_jenkins_io
+    scmid: default
+
+  updateLdapJenkinsIoIP:
+    name: Update ldap.jenkins.io external IP in locals.tf
+    kind: hcl
+    sourceid: getLdapJenkinsIoIP
+    spec:
+      file: locals.tf
+      path: locals.external_ip_ldap_jenkins_io
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Update the external IPs from public DNS records
+    spec:
+      labels:
+        - dependencies
+        - external-ips


### PR DESCRIPTION
This PR automates the three `external_ips` entries in `locals.tf` that were flagged with `# TODO: automate retrieval of this IP with updatecli`.

- `puppet.jenkins.io` 
- `ldap.jenkins.io`
- `s390x.ci.jenkins.io`

Values are converted to scalar locals so the HCL target can address them, the map keys contain dots, which the HCL parser can't target directly 

## Testing done
- `updatecli diff` against current `main`: all three sources resolve (`20.12.27.65`, `20.57.70.169`, `148.100.84.76`), all targets bind (`Changed: 0, Failed: 0, Succeeded: 1`).
- `terraform fmt` clean.

tested locally with success:

```
✔ Update external IPs from public DNS records:
        Source:
                ✔ [getLdapJenkinsIoIP] Retrieve the public IPv4 for ldap.jenkins.io
                ✔ [getPuppetJenkinsIoIP] Retrieve the public IPv4 for puppet.jenkins.io
                ✔ [getS390xAgentIP] Retrieve the s390x permanent agent IP from jenkins-infra hieradata
        Target:
                ✔ [updateLdapJenkinsIoIP] Update ldap.jenkins.io external IP in locals.tf
                ✔ [updatePuppetJenkinsIoIP] Update puppet.jenkins.io external IP in locals.tf
                ✔ [updateS390xAgentIP] Update s390x.ci.jenkins.io external IP in locals.tf


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```
