### PR TITLE
chore(Jenkinsfile_updatecli) fix cron triggers to ensure a daily execution

### DIFF
--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -2,11 +2,10 @@ withCredentials([
     string(credentialsId: 'updatecli-aws-access-key-id', variable: 'AWS_ACCESS_KEY_ID'),
     string(credentialsId: 'updatecli-aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY')
 ]) {
-    if (env.BRANCH_IS_PRIMARY) {
-        // Only trigger a daily check on the principal branch
-        properties([pipelineTriggers([cron('@daily')])])
-        updatecli(action: 'apply')
-    } else {
-        updatecli(action: 'diff')
-    }
+    final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
+    updatecli(
+        action: updatecliAction,
+        runInCurrentAgent: true,
+        cronTriggerExpression: env.BRANCH_IS_PRIMARY ? '@daily' : '',
+    )
 }

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -5,7 +5,6 @@ withCredentials([
     final String updatecliAction = env.BRANCH_IS_PRIMARY ? 'apply' : 'diff'
     updatecli(
         action: updatecliAction,
-        runInCurrentAgent: true,
         cronTriggerExpression: env.BRANCH_IS_PRIMARY ? '@daily' : '',
     )
 }


### PR DESCRIPTION
## Problem

As caught by @jayfranco999 earlier today, it seems that the `updatecli` pipeline is not executed once a day as expected.

Pipeline steps of the last (manually) run shows 2 calls to the `properties` pipeline step:
<img width="1558" height="425" alt="Capture d’écran 2026-07-24 à 15 28 10" src="https://github.com/user-attachments/assets/3b1942f7-5f87-42fd-bd01-24b0d8ae20bf" />

which always lead to an empty cron trigger section:

<img width="990" height="201" alt="Capture d’écran 2026-07-24 à 15 27 41" src="https://github.com/user-attachments/assets/dae702cb-94c4-42d7-aa39-d7b055e2fd64" />

## Cause

Current pipeline is calling the `properties` on the main branch only **before** calling the `updatecli()` library  => first call to `properties` with the correct cron trigger.

But the current version of the `updatecli()` pipeline library does disable the cron trigger if not specified: https://github.com/jenkins-infra/pipeline-library/blob/4b4841efa3ae5349411f9866df7f474a54320741/vars/updatecli.groovy#L11. => second call with an empty (disabled) cron trigger.

## Solution

Same pattern as https://github.com/jenkins-infra/kubernetes-management/blob/main/Jenkinsfile_updatecli