### PR TITLE
refactor(locals): move updatecli-tracked values to locals-data.yaml

### DIFF
--- a/eks-cijenkinsio-agents-2.tf
+++ b/eks-cijenkinsio-agents-2.tf
@@ -72,7 +72,7 @@ module "cijenkinsio_agents_2" {
   addons = {
     coredns = {
       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-      addon_version = local.cijenkinsio_agents_2_cluster_addons_coredns_addon_version
+      addon_version = local.cijenkinsio_agents_2["cluster_addons"]["coredns"]
       configuration_values = jsonencode({
         "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
       })
@@ -82,13 +82,13 @@ module "cijenkinsio_agents_2" {
     # See https://kubernetes.io/releases/version-skew-policy/#kube-proxy
     kube-proxy = {
       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-      addon_version               = local.cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version
+      addon_version               = local.cijenkinsio_agents_2["cluster_addons"]["kube_proxy"]
       resolve_conflicts_on_create = "OVERWRITE"
     }
     # https://github.com/aws/amazon-vpc-cni-k8s/releases
     vpc-cni = {
       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-      addon_version = local.cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version
+      addon_version = local.cijenkinsio_agents_2["cluster_addons"]["vpc_cni"]
       # Ensure vpc-cni changes are applied before any EC2 instances are created
       before_compute = true
       configuration_values = jsonencode({
@@ -100,7 +100,7 @@ module "cijenkinsio_agents_2" {
     ## https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md
     aws-ebs-csi-driver = {
       # https://docs.aws.amazon.com/cli/latest/reference/eks/describe-addon-versions.html
-      addon_version = local.cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version
+      addon_version = local.cijenkinsio_agents_2["cluster_addons"]["aws_ebs_csi_driver"]
       configuration_values = jsonencode({
         "controller" = {
           "tolerations" = local.cijenkinsio_agents_2["system_node_pool"]["tolerations"],
@@ -114,7 +114,7 @@ module "cijenkinsio_agents_2" {
     },
     ## https://github.com/awslabs/mountpoint-s3-csi-driver
     aws-mountpoint-s3-csi-driver = {
-      addon_version = local.cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version
+      addon_version = local.cijenkinsio_agents_2["cluster_addons"]["aws_s3_csi_driver"]
       # resolve_conflicts_on_create = "OVERWRITE"
       configuration_values = jsonencode({
         "node" = {
@@ -125,7 +125,7 @@ module "cijenkinsio_agents_2" {
       resolve_conflicts_on_create = "OVERWRITE"
     },
     eks-pod-identity-agent = {
-      addon_version = local.cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version
+      addon_version = local.cijenkinsio_agents_2["cluster_addons"]["eks_pod_identity_agent"]
     },
   }
 
@@ -137,7 +137,7 @@ module "cijenkinsio_agents_2" {
       capacity_type  = "ON_DEMAND"
       # Starting on 1.30, AL2023 is the default AMI type for EKS managed node groups
       ami_type            = "AL2023_ARM_64_STANDARD"
-      ami_release_version = local.cijenkinsio_agents_2_ami_release_version
+      ami_release_version = local.cijenkinsio_agents_2["eks_ami_release_version"]
       min_size            = 2
       max_size            = 3 # Usually 2 nodes, but accept 1 additional surging node
       desired_size        = 2
@@ -744,7 +744,7 @@ resource "kubernetes_manifest" "cijenkinsio_agents_2_karpenter_nodeclasses" {
           # Few notes about AMI aliases (ref. karpenter and AWS EKS docs.)
           # - WindowsXXXX only has the "latest" version available
           # - Amazon Linux 2023 is our default OS choice for Linux containers nodes
-          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v${split("-", local.cijenkinsio_agents_2_ami_release_version)[1]}"
+          alias = startswith(each.value.os, "windows") ? "${replace(each.value.os, "-", "")}@latest" : "al2023@v${split("-", local.cijenkinsio_agents_2["eks_ami_release_version"])[1]}"
         }
       ]
     }

--- a/locals-data.yaml
+++ b/locals-data.yaml
@@ -95,3 +95,24 @@ ci.jenkins.io:
       os_version: 2019
       os: windows
       pricing_types: ["spot", "ondemand"]
+cijenkinsio-agents-2:
+  # Tracked by updatecli from AWS EKS addon versions
+  eks_addons:
+    coredns: v1.13.2-eksbuild.11
+    kube_proxy: v1.34.6-eksbuild.18
+    vpc_cni: v1.22.4-eksbuild.3
+    aws_ebs_csi_driver: v1.63.1-eksbuild.1
+    aws_s3_csi_driver: v1.15.0-eksbuild.1
+    # Not tracked by updatecli yet
+    eks_pod_identity_agent: v1.3.10-eksbuild.3
+  # Tracked by updatecli from AWS SSM (EKS optimized AMI release version)
+  eks_ami_release_version: 1.34.9-20260801
+#####
+## External and outbounds IP used by resources for network restrictions.
+## Note: we use scalar (strings with space separator) as the updatecli source returns
+##   a space-separated list, split back into lists in locals.tf.
+#####
+# Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
+outbound_ips:
+  infra.ci.jenkins.io: 20.57.120.46 52.179.141.53 20.186.168.195 20.65.112.39 20.97.161.208 52.251.34.201
+  private.vpn.jenkins.io: 52.232.183.117

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  # Values tracked and updated by updatecli, stored in locals-data.yaml
-  updatecli_data = yamldecode(file("${path.module}/locals-data.yaml"))
+  # external YAML file, mainly to ease updatecli tracking (HCL nested maps aren't supported)
+  yaml_data = yamldecode(file("${path.module}/locals-data.yaml"))
 
   aws_account_id = "326712726440"
   region         = "us-east-2"
@@ -18,8 +18,8 @@ locals {
   cijenkinsio_agents_2 = {
     # TODO: where does the values come from?
     api-ipsv4               = ["10.0.131.86/32", "10.0.133.102/32"]
-    cluster_addons          = local.updatecli_data["cijenkinsio-agents-2"]["eks_addons"]
-    eks_ami_release_version = local.updatecli_data["cijenkinsio-agents-2"]["eks_ami_release_version"]
+    cluster_addons          = local.yaml_data["cijenkinsio-agents-2"]["eks_addons"]
+    eks_ami_release_version = local.yaml_data["cijenkinsio-agents-2"]["eks_ami_release_version"]
     karpenter = {
       node_role_name = "KarpenterNodeRole-cijenkinsio-agents-2",
       namespace      = "karpenter",
@@ -143,7 +143,7 @@ locals {
   }
 
   outbound_ips = {
-    for service, ips in local.updatecli_data["outbound_ips"] : service => split(" ", ips)
+    for service, ips in local.yaml_data["outbound_ips"] : service => split(" ", ips)
   }
   external_ips = {
     # Jenkins Puppet Master
@@ -211,13 +211,13 @@ locals {
     },
   ]
 
-  ami_ids = local.updatecli_data["ami_ids"]
+  ami_ids = local.yaml_data["ami_ids"]
 
   # Launch template definitions are the same for different ASGs (usually spot/ondemand)
   ci_jenkins_io_launch_template_definitions = {
     # Flatten into one entry per (os_version, jdk) pair
     for pair in flatten([
-      for agent_key, agent_value in local.updatecli_data["ci.jenkins.io"]["ec2_agents"] : [
+      for agent_key, agent_value in local.yaml_data["ci.jenkins.io"]["ec2_agents"] : [
         for jdk in agent_value.jdks : {
           key = "${agent_key}-jdk${jdk}"
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  # Values tracked and updated by updatecli, stored in locals-data.yaml
+  updatecli_data = yamldecode(file("${path.module}/locals-data.yaml"))
+
   aws_account_id = "326712726440"
   region         = "us-east-2"
 
@@ -12,18 +15,11 @@ locals {
     controller_vm_fqdn = "aws.ci.jenkins.io"
   }
 
-  cijenkinsio_agents_2_cluster_addons_coredns_addon_version             = "v1.13.2-eksbuild.11"
-  cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version           = "v1.34.6-eksbuild.18"
-  cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version              = "v1.22.4-eksbuild.3"
-  cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version     = "v1.63.1-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version      = "v1.15.0-eksbuild.1"
-  cijenkinsio_agents_2_cluster_addons_eksPodIdentityAgent_addon_version = "v1.3.10-eksbuild.3"
-
-  cijenkinsio_agents_2_ami_release_version = "1.34.9-20260801"
-
   cijenkinsio_agents_2 = {
     # TODO: where does the values come from?
-    api-ipsv4 = ["10.0.131.86/32", "10.0.133.102/32"]
+    api-ipsv4               = ["10.0.131.86/32", "10.0.133.102/32"]
+    cluster_addons          = local.updatecli_data["cijenkinsio-agents-2"]["eks_addons"]
+    eks_ami_release_version = local.updatecli_data["cijenkinsio-agents-2"]["eks_ami_release_version"]
     karpenter = {
       node_role_name = "KarpenterNodeRole-cijenkinsio-agents-2",
       namespace      = "karpenter",
@@ -146,21 +142,8 @@ locals {
     "PreferNoSchedule" = "PREFER_NO_SCHEDULE",
   }
 
-  #####
-  ## External and outbounds IP used by resources for network restrictions.
-  ## Note: we use scalar (strings with space separator) to manage type changes by updatecli's HCL parser
-  ##   and a map with complex type (list or strings). Ref. https://github.com/updatecli/updatecli/issues/1859#issuecomment-1884876679
-  #####
-  # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
-  outbound_ips_infra_ci_jenkins_io = "20.57.120.46 52.179.141.53 20.186.168.195 20.65.112.39 20.97.161.208 52.251.34.201"
-  # Tracked by 'updatecli' from the following source: https://reports.jenkins.io/jenkins-infra-data-reports/azure-net.json
-  outbound_ips_private_vpn_jenkins_io = "52.232.183.117"
-
   outbound_ips = {
-    # Terraform management and Docker-packaging build
-    "infra.ci.jenkins.io" = split(" ", local.outbound_ips_infra_ci_jenkins_io)
-    # Connections routed through the VPN
-    "private.vpn.jenkins.io" = split(" ", local.outbound_ips_private_vpn_jenkins_io),
+    for service, ips in local.updatecli_data["outbound_ips"] : service => split(" ", ips)
   }
   external_ips = {
     # Jenkins Puppet Master
@@ -228,13 +211,13 @@ locals {
     },
   ]
 
-  ami_ids = yamldecode(file("${path.module}/locals-data.yaml"))["ami_ids"]
+  ami_ids = local.updatecli_data["ami_ids"]
 
   # Launch template definitions are the same for different ASGs (usually spot/ondemand)
   ci_jenkins_io_launch_template_definitions = {
     # Flatten into one entry per (os_version, jdk) pair
     for pair in flatten([
-      for agent_key, agent_value in yamldecode(file("${path.module}/locals-data.yaml"))["ci.jenkins.io"]["ec2_agents"] : [
+      for agent_key, agent_value in local.updatecli_data["ci.jenkins.io"]["ec2_agents"] : [
         for jdk in agent_value.jdks : {
           key = "${agent_key}-jdk${jdk}"
 


### PR DESCRIPTION
Moves the updatecli-tracked values (EKS addon versions, AMI release version, outbound IPs) out of `locals.tf` into `locals-data.yaml`, decoded once into a single `local.yaml_data`.

Following review feedback, the tracked EKS values are scoped under a `cijenkinsio-agents-2:` key in the YAML rather than top-level, and are consumed from inside the existing `cijenkinsio_agents_2` local so they sit alongside `karpenter`/`awslb`/`system_node_pool`. `outbound_ips` stays top-level as it is shared infra data, not cluster-scoped.

`eks_pod_identity_agent` moved with the rest for consistency even though nothing tracks it yet (noted in the YAML).

### Testing done

- `terraform fmt -check -recursive` and `terraform validate` pass.
- `terraform plan` on infra.ci reports no changes:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

(The remaining plan warnings are pre-existing `kubernetes` provider deprecations on lines untouched by this PR.)

Merge order: this PR first, then the matching updatecli manifest changes:

1. #586
2. #587
