### PR TITLE
chore(updatecli): target locals-data.yaml instead of locals.tf

### DIFF
--- a/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
@@ -45,7 +45,7 @@ targets:
     sourceid: getLatestAwsEbsCsiDriverVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_addons.aws_ebs_csi_driver
+      key: $.'cijenkinsio-agents-2'.eks_addons.aws_ebs_csi_driver
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-ebs-csi-driver.yaml
@@ -1,4 +1,4 @@
-name: Bump EKS aws-ebs-csi-driver Addons versions in eks-cijenkinsio-agents-2.tf
+name: Bump EKS aws-ebs-csi-driver Addons versions in locals-data.yaml
 
 scms:
   default:
@@ -40,12 +40,12 @@ sources:
 
 targets:
   upgradeAwsEbsCsiDriverVersion:
-    name: Update the aws-ebs-csi-driver addon version in eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the aws-ebs-csi-driver addon version in locals-data.yaml
+    kind: yaml
     sourceid: getLatestAwsEbsCsiDriverVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_cluster_addons_awsEbsCsiDriver_addon_version
+      file: locals-data.yaml
+      key: $.eks_addons.aws_ebs_csi_driver
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
@@ -45,7 +45,7 @@ targets:
     sourceid: getLatestAwsS3CsiDriverVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_addons.aws_s3_csi_driver
+      key: $.'cijenkinsio-agents-2'.eks_addons.aws_s3_csi_driver
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-aws-s3-csi-driver .yaml
@@ -40,12 +40,12 @@ sources:
 
 targets:
   upgradeAwsS3CsiDriverVersion:
-    name: Update the aws-mountpoint-s3-csi-driver addon version in eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the aws-mountpoint-s3-csi-driver addon version in locals-data.yaml
+    kind: yaml
     sourceid: getLatestAwsS3CsiDriverVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_cluster_addons_awsS3CsiDriver_addon_version
+      file: locals-data.yaml
+      key: $.eks_addons.aws_s3_csi_driver
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
@@ -1,4 +1,4 @@
-name: Bump EKS Coredns Addons versions in eks-cijenkinsio-agents-2.tf
+name: Bump EKS Coredns Addons versions in locals-data.yaml
 
 scms:
   default:
@@ -40,12 +40,12 @@ sources:
 
 targets:
   upgradeCoreDnsVersion:
-    name: Update the coredns addon version in eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the coredns addon version in locals-data.yaml
+    kind: yaml
     sourceid: getLatestCoreDnsVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_cluster_addons_coredns_addon_version
+      file: locals-data.yaml
+      key: $.eks_addons.coredns
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-coredns.yaml
@@ -45,7 +45,7 @@ targets:
     sourceid: getLatestCoreDnsVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_addons.coredns
+      key: $.'cijenkinsio-agents-2'.eks_addons.coredns
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
@@ -1,4 +1,4 @@
-name: Bump EKS kube-proxy Addons versions in eks-cijenkinsio-agents-2.tf
+name: Bump EKS kube-proxy Addons versions in locals-data.yaml
 
 scms:
   default:
@@ -40,12 +40,12 @@ sources:
 
 targets:
   upgradeKubeProxyVersion:
-    name: Update the kube-proxy addon version in eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the kube-proxy addon version in locals-data.yaml
+    kind: yaml
     sourceid: getLatestKubeProxyVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_cluster_addons_kubeProxy_addon_version
+      file: locals-data.yaml
+      key: $.eks_addons.kube_proxy
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-kube-proxy.yaml
@@ -45,7 +45,7 @@ targets:
     sourceid: getLatestKubeProxyVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_addons.kube_proxy
+      key: $.'cijenkinsio-agents-2'.eks_addons.kube_proxy
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
@@ -45,7 +45,7 @@ targets:
     sourceid: getLatestVpcCniVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_addons.vpc_cni
+      key: $.'cijenkinsio-agents-2'.eks_addons.vpc_cni
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
+++ b/updatecli/updatecli.d/eks-addons/eks-vpc-cni.yaml
@@ -1,4 +1,4 @@
-name: Bump EKS vpc-cni Addons versions in eks-cijenkinsio-agents-2.tf
+name: Bump EKS vpc-cni Addons versions in locals-data.yaml
 
 scms:
   default:
@@ -40,12 +40,12 @@ sources:
 
 targets:
   upgradeVpcCniVersion:
-    name: Update the vpc-cni addon version in eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the vpc-cni addon version in locals-data.yaml
+    kind: yaml
     sourceid: getLatestVpcCniVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_cluster_addons_vpcCni_addon_version
+      file: locals-data.yaml
+      key: $.eks_addons.vpc_cni
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -48,7 +48,7 @@ targets:
     sourceid: getLatestAmiReleaseVersion
     spec:
       file: locals-data.yaml
-      key: $.eks_ami_release_version
+      key: $.'cijenkinsio-agents-2'.eks_ami_release_version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/eks-ami-release.yaml
+++ b/updatecli/updatecli.d/eks-ami-release.yaml
@@ -1,4 +1,4 @@
-name: Bump AMI release version for EKS managed node groups in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
+name: Bump AMI release version for EKS managed node groups in terraform-aws-sponsorship/locals-data.yaml
 
 scms:
   default:
@@ -43,12 +43,12 @@ sources:
 
 targets:
   upgradeAMIVersion:
-    name: Update the AMI release version in terraform-aws-sponsorship/eks-cijenkinsio-agents-2.tf
-    kind: hcl
+    name: Update the AMI release version in terraform-aws-sponsorship/locals-data.yaml
+    kind: yaml
     sourceid: getLatestAmiReleaseVersion
     spec:
-      file: locals.tf
-      path: locals.cijenkinsio_agents_2_ami_release_version
+      file: locals-data.yaml
+      key: $.eks_ami_release_version
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/outbound-ips.yaml
+++ b/updatecli/updatecli.d/outbound-ips.yaml
@@ -34,19 +34,19 @@ sources:
 targets:
   infra-ci-agents-update:
     name: Update infracijenkinsioagents1.jenkins.io IPs
-    kind: hcl
+    kind: yaml
     spec:
-      file: locals.tf
-      path: locals.outbound_ips_infra_ci_jenkins_io
+      file: locals-data.yaml
+      key: $.outbound_ips.'infra.ci.jenkins.io'
     sourceid: infra-ci-agents-ips
     scmid: default
 
   private-vpn-update:
     name: Update private_vpn.jenkins.io IPs
-    kind: hcl
+    kind: yaml
     spec:
-      file: locals.tf
-      path: locals.outbound_ips_private_vpn_jenkins_io
+      file: locals-data.yaml
+      key: $.outbound_ips.'private.vpn.jenkins.io'
     sourceid: private-vpn-ips
     scmid: default
 


### PR DESCRIPTION
Follow-up to #586, which moves the tracked values out of `locals.tf` and into `locals-data.yaml`. This switches the matching targets from `hcl` to `yaml` so they write to the new location, following the pattern already used by `ec2-agents-ami.yaml`.

The `getClusterKubernetesVersion` sources stay `hcl`: they read `module.cijenkinsio_agents_2.kubernetes_version` from `eks-cijenkinsio-agents-2.tf`, which is unaffected.

Also fixes the manifest and target names that still said `eks-cijenkinsio-agents-2.tf`, since the addon versions have not lived there for a while.

### Testing done

`updatecli diff` on all 7 manifests against the `locals-data.yaml` from #586: every target resolves its key and reports no change, including the dotted keys (`$.outbound_ips.'infra.ci.jenkins.io'`). 

### Note on merge order

These two PRs are coupled: a `yaml` target pointing at a key that does not exist yet fails with `couldn't find key`. So #586 has to merge first, then this one, otherwise the daily updatecli run breaks in between.
